### PR TITLE
Add resource xClusterPreferredOwner

### DIFF
--- a/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.psm1
+++ b/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.psm1
@@ -7,10 +7,11 @@
 #
 function Get-TargetResource
 {
+    [OutputType([Hashtable])]
     param
     (	
         [parameter(Mandatory)]
-        [string[]]
+        [string]
         $ClusterGroup,
 
         [parameter(Mandatory)]
@@ -56,7 +57,7 @@ function Set-TargetResource
     param
     (	
         [parameter(Mandatory)]
-        [string[]]
+        [string]
         $ClusterGroup,
 
         [parameter(Mandatory)]
@@ -138,10 +139,11 @@ function Set-TargetResource
 
 function Test-TargetResource  
 {
+    [OutputType([Boolean])]
     param
     (	
         [parameter(Mandatory)]
-        [string[]]
+        [string]
         $ClusterGroup,
 
         [parameter(Mandatory)]

--- a/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.psm1
+++ b/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.psm1
@@ -1,0 +1,211 @@
+﻿#
+# cClusterPreferredOwner: DSC resource to configure the Windows Failover Cluster Preferred Owner.
+#
+
+#
+# The Get-TargetResource cmdlet.
+#
+function Get-TargetResource
+{
+    param
+    (	
+        [parameter(Mandatory)]
+        [string[]]
+        $ClusterGroup,
+
+        [parameter(Mandatory)]
+        [string]
+        $Clustername,
+
+        [parameter(Mandatory)]
+        [string[]]
+        $Nodes,
+
+        [string[]]
+        $ClusterResources,
+
+        [ValidateSet('Present', 'Absent')]
+		[String]
+		$Ensure = 'Present'
+    )
+    
+    Write-Verbose -Message "Retrieving Owner information for cluster $Clustername..."
+
+    $ownernodes = @(
+        
+        Write-Verbose -Message "Retrieving Owner information for Cluster Group $ClusterGroup"
+        (((Get-Cluster $Clustername | Get-ClusterGroup | Where-Object {$_.name -like "$ClusterGroup"}) | Get-ClusterOwnerNode).ownernodes).name
+
+        if ($ClusterResources)
+        {
+            foreach ($resource in $ClusterResources)
+            {
+                Write-Verbose -Message "Retrieving Owner information for Cluster Resource $resource"
+                (((Get-Cluster $Clustername | get-ClusterResource | Where-Object {$_.name -like "$resource"}) | Get-ClusterOwnerNode).ownernodes).name
+            }
+        }
+    )
+    $ownernodes | Select-Object -Unique
+}
+
+#
+# The Set-TargetResource cmdlet.
+#
+function Set-TargetResource
+{
+    param
+    (	
+        [parameter(Mandatory)]
+        [string[]]
+        $ClusterGroup,
+
+        [parameter(Mandatory)]
+        [string]
+        $Clustername,
+
+        [parameter(Mandatory)]
+        [string[]]
+        $Nodes,
+
+        [string[]]
+        $ClusterResources,
+
+        [ValidateSet('Present', 'Absent')]
+		[String]
+		$Ensure = 'Present'
+    )
+
+    Write-Verbose -Message "Retrieving all owners from cluster $Clustername"
+    $allnodes = (Get-Cluster $ClusterName | Get-ClusterNode).name
+
+    if ($Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Setting Cluster owners for Group $ClusterGroup to $nodes" -Verbose
+        Get-Cluster $ClusterName  | Get-ClusterGroup | Where-Object {$_.name -like $ClusterGroup} | Set-ClusterOwnerNode $Nodes
+        Get-Cluster $ClusterName  | Get-ClusterGroup | Where-Object {$_.name -like $ClusterGroup} | Get-ClusterResource | Set-ClusterOwnerNode $allnodes
+        Write-Verbose -Message "Moving Cluster Group $ClusterGroup to node $($nodes[0])" -Verbose
+        Get-Cluster $ClusterName  | Get-ClusterGroup | Where-Object {$_.name -like $ClusterGroup} | Move-ClusterGroup -Node $Nodes[0]
+        foreach ($resource in $ClusterResources)
+        {
+            Write-Verbose -Message "Setting Cluster owners for Resource $resource to $nodes" -Verbose
+            Get-Cluster $ClusterName  | Get-ClusterResource | Where-Object {$_.name -like "$resource"} | Set-ClusterOwnerNode -owners $Nodes
+        }
+    }
+    if ($Ensure -eq 'Absent')
+    {          
+
+            Write-Verbose -Message "Retrieving current clusterowners for group $ClusterGroup" -Verbose
+            $currentowners = (((Get-Cluster $Clustername | Get-ClusterGroup | Where-Object {$_.name -like "$ClusterGroup"}) | Get-ClusterOwnerNode).ownernodes).name | Sort-Object -Unique
+            $newowners = @(
+                foreach ($currentowner in $currentowners)
+                {
+                    if ($Nodes -notcontains $currentowner)
+                    {
+                        $currentowner
+                    }
+                }
+            )
+            Write-Verbose -Message "Removing owners from group $($ClusterGroup): $Nodes"
+            Write-Verbose -Message "Setting Cluster owners for Group $ClusterGroup to $newowners" -Verbose
+            Get-Cluster $ClusterName  | Get-ClusterGroup | Where-Object {$_.name -like $ClusterGroup} | Set-ClusterOwnerNode $newowners
+            Get-Cluster $ClusterName  | Get-ClusterGroup | Where-Object {$_.name -like $ClusterGroup} | Get-ClusterResource | Set-ClusterOwnerNode $allnodes
+            Write-Verbose -Message "Moving Cluster Group $ClusterGroup to node $($newowners[0])" -Verbose
+            Get-Cluster $ClusterName  | Get-ClusterGroup | Where-Object {$_.name -like $ClusterGroup} | Move-ClusterGroup -Node $newowners[0]
+
+        foreach ($resource in $ClusterResources)
+        {
+            Write-Verbose -Message "Retrieving current clusterowners for resource $resource" -Verbose
+            $currentowners = ((Get-Cluster $Clustername | Get-ClusterResource | Where-Object {$_.name -like "$resource"} | Get-ClusterOwnerNode).ownernodes).name | Sort-Object -Unique
+            $newowners = @(
+                foreach ($currentowner in $currentowners)
+                {
+                    if ($Nodes -notcontains $currentowner)
+                    {
+                        $currentowner
+                    }
+                }
+            )
+            Write-Verbose -Message "Removing owners from resource $($resource): $Nodes"
+            Write-Verbose -Message "Setting Cluster owners for Resource $resource to $newowners" -Verbose
+            Get-Cluster $ClusterName  | Get-ClusterResource | Where-Object {$_.name -like "$resource"} | Set-ClusterOwnerNode -owners $newowners
+        }
+    } 
+}
+
+# 
+# Test-TargetResource
+#
+
+function Test-TargetResource  
+{
+    param
+    (	
+        [parameter(Mandatory)]
+        [string[]]
+        $ClusterGroup,
+
+        [parameter(Mandatory)]
+        [string]
+        $Clustername,
+
+        [parameter(Mandatory)]
+        [string[]]
+        $Nodes,
+
+        [string[]]
+        $ClusterResources,
+
+        [ValidateSet('Present', 'Absent')]
+		[String]
+		$Ensure = 'Present'
+    )
+
+    Write-Verbose -Message "Testing Owner information for cluster $Clustername..."
+
+    $getinfo = Get-TargetResource @PSBoundParameters
+    $result = $true
+
+    if ($Ensure -eq 'Present')
+        {
+        foreach ($object in $getinfo)
+        {
+            if ($Nodes -notcontains $object)
+            {
+                Write-Verbose -Message "$object was NOT found as possible owner"
+                $result = $false
+            }
+        }
+        foreach ($object in $nodes)
+        {
+            if ($getinfo -notcontains $object)
+            {
+                Write-Verbose -Message "$object was NOT found as possible owner"
+                $result = $false
+            }
+
+        }
+    }
+
+    if ($Ensure -eq 'Absent')
+        {
+        foreach ($object in $getinfo)
+        {
+            if ($Nodes -contains $object)
+            {
+                Write-Verbose -Message "$object WAS found as possible owner"
+                $result = $false
+            }
+        }
+        foreach ($object in $nodes)
+        {
+            if ($getinfo -contains $object)
+            {
+                Write-Verbose -Message "$object WAS found as possible owner"
+                $result = $false
+            }
+
+        }
+    }
+
+    $result
+}

--- a/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
+++ b/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
@@ -1,0 +1,9 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xClusterPreferredOwner")]
+class MSFT_xClusterPreferredOwner : OMI_BaseResource
+{
+    [Key] string ClusterGroup;
+    [Required] string Clustername;
+    [Required] string Nodes[];
+    [Write] string ClusterResources[];
+    [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
+};

--- a/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
+++ b/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
@@ -1,9 +1,11 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xClusterPreferredOwner")]
 class MSFT_xClusterPreferredOwner : OMI_BaseResource
 {
-    [Key] string ClusterGroup;
-    [Required] string Clustername;
-    [Required] string Nodes[];
-    [Write] string ClusterResources[];
-    [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
+    [key] string ClusterGroup;
+    [required] string Clustername;
+    [required] string Nodes;
+    [write] string ClusterResources[];
+    [write, valuemap{"Present", "Absent"}, values{"Present", "Absent"}] string Ensure;
 };
+
+

--- a/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
+++ b/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xClusterPreferredOwner")]
 class MSFT_xClusterPreferredOwner : OMI_BaseResource
 {
-    [key] string ClusterGroup[];
+    [key] string ClusterGroup;
     [required] string Clustername;
     [required] string Nodes[];
     [write] string ClusterResources[];

--- a/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
+++ b/DSCResources/MSFT_xClusterPreferredOwner/MSFT_xClusterPreferredOwner.schema.mof
@@ -1,9 +1,9 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xClusterPreferredOwner")]
 class MSFT_xClusterPreferredOwner : OMI_BaseResource
 {
-    [key] string ClusterGroup;
+    [key] string ClusterGroup[];
     [required] string Clustername;
-    [required] string Nodes;
+    [required] string Nodes[];
     [write] string ClusterResources[];
     [write, valuemap{"Present", "Absent"}, values{"Present", "Absent"}] string Ensure;
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/6a59vfritv4kbc7d/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xfailovercluster/branch/master)
+﻿[![Build status](https://ci.appveyor.com/api/projects/status/6a59vfritv4kbc7d/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xfailovercluster/branch/master)
 
 # xFailOverCluster
 
@@ -26,7 +26,19 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **RetryCount**: Maximum number of retries to check for cluster existance
 * **Credential**: Credential used to join or leave domain
 
+### xClusterPreferredOwner
+
+* **ClusterGroup**: Name of the Cluster Group
+* **Clustername**: Name of the Cluster
+* **Nodes**: Name of the Clusternode(s)
+* **ClusterResources**: Name of the Cluster Resource(s)
+* **Ensure**: Ensure that the selected nodes become the only owner (present), or are removed from ownership (absent)
+
 ## Versions
+
+### Unreleased
+
+* Added new resource xClusterPreferredOwner
 
 ### 1.1.0.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ﻿[![Build status](https://ci.appveyor.com/api/projects/status/6a59vfritv4kbc7d/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xfailovercluster/branch/master)
 
-
 # xFailOverCluster
 
 The **xFailOverCluster** DSC modules contains **xCluster** and **xWaitForCluster** resources for creating and configuring failover clusters. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ﻿[![Build status](https://ci.appveyor.com/api/projects/status/6a59vfritv4kbc7d/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xfailovercluster/branch/master)
 
+
 # xFailOverCluster
 
 The **xFailOverCluster** DSC modules contains **xCluster** and **xWaitForCluster** resources for creating and configuring failover clusters. 


### PR DESCRIPTION
This new resource was created to change the preferred owners of a cluster resource.
This can for example be used when setting up SQL Always-On between 2 SQL FCI's using DSC.