### PR TITLE
Added '-NoStorage' to add-clusternode cmdlet - fixed issue #4

### DIFF
--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -126,7 +126,7 @@ function Set-TargetResource
                 }
             }
 
-            Add-ClusterNode $env:COMPUTERNAME -Cluster $Name
+            Add-ClusterNode $env:COMPUTERNAME -Cluster $Name -NoStorage
             
             Write-Verbose -Message "Added node to Cluster $Name"
         

--- a/README.md
+++ b/README.md
@@ -166,3 +166,10 @@ $domainAdminCred = Get-Credential -UserName "ClusterDemo\Administrator" -Message
 
 ClusterDemo -ConfigurationData $ConfigData -domainAdminCred $domainAdminCred
 ```
+
+### Unreleased
+xCluster: Added -NoStorage switch to add-clusterNode
+
+This prevents disks from being automatically added when joining a node to a cluster
+
+Addressed Issue #4


### PR DESCRIPTION
Added the '-NoStorage' switch to ensure that disks do not automatically get added to the cluster when adding nodes.