### PR TITLE
Fix: replaced ResourceType with ResourceType.Name

### DIFF
--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
@@ -19,7 +19,7 @@ function Get-TargetResource
     if ($null -ne ($DiskInstance = Get-CimInstance -ClassName MSCluster_Disk -Namespace 'Root\MSCluster' -Filter "Number = $Number"))
     {
         $DiskResource = Get-ClusterResource |
-                            Where-Object { $_.ResourceType -eq 'Physical Disk' } |
+                            Where-Object { $_.ResourceType.Name -eq 'Physical Disk' } |
                                 Where-Object { ($_ | Get-ClusterParameter -Name DiskIdGuid).Value -eq $DiskInstance.Id }
 
         @{
@@ -74,7 +74,7 @@ function Set-TargetResource
                 $DiskInstance = Get-CimInstance -ClassName MSCluster_Disk -Namespace 'Root\MSCluster' -Filter "Number = $Number"
 
                 $DiskResource = Get-ClusterResource |
-                                    Where-Object { $_.ResourceType -eq 'Physical Disk' } |
+                                    Where-Object { $_.ResourceType.Name -eq 'Physical Disk' } |
                                         Where-Object { ($_ | Get-ClusterParameter -Name DiskIdGuid).Value -eq $DiskInstance.Id }
 
                 # Set the label of the cluster disk
@@ -89,7 +89,7 @@ function Set-TargetResource
             $DiskInstance = Get-CimInstance -ClassName MSCluster_Disk -Namespace 'Root\MSCluster' -Filter "Number = $Number"
 
             $DiskResource = Get-ClusterResource |
-                                Where-Object { $_.ResourceType -eq 'Physical Disk' } |
+                                Where-Object { $_.ResourceType.Name -eq 'Physical Disk' } |
                                     Where-Object { ($_ | Get-ClusterParameter -Name DiskIdGuid).Value -eq $DiskInstance.Id }
             
             # Remove the cluster disk

--- a/Tests/MSFT_xClusterDisk.Tests.ps1
+++ b/Tests/MSFT_xClusterDisk.Tests.ps1
@@ -40,19 +40,19 @@ Describe 'xClusterDisk' {
             @(
                 [PSCustomObject] @{
                     Name         = 'Cluster IP Address'
-                    ResourceType = 'IP Address'
+                    ResourceType = @{ Name = 'IP Address', DisplayName = 'IP Address' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
                 [PSCustomObject] @{
                     Name         = 'Clsuter Name'
-                    ResourceType = 'Network Name'
+                    ResourceType = @{ Name = 'Network Name', DisplayName = 'Network Name' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
                 [PSCustomObject] @{
                     Name         = 'First Data'
-                    ResourceType = 'Physical Disk'
+                    ResourceType = @{ Name = 'Physical Disk', DisplayName = 'Physical Disk' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
                 [PSCustomObject] @{
                     Name         = 'Witness'
-                    ResourceType = 'Physical Disk'
+                    ResourceType = @{ Name = 'Physical Disk', DisplayName = 'Physical Disk' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
             )
         }

--- a/Tests/MSFT_xClusterDisk.Tests.ps1
+++ b/Tests/MSFT_xClusterDisk.Tests.ps1
@@ -40,19 +40,15 @@ Describe 'xClusterDisk' {
             @(
                 [PSCustomObject] @{
                     Name         = 'Cluster IP Address'
-                    ResourceType = @{ Name = 'IP Address', DisplayName = 'IP Address' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
                 [PSCustomObject] @{
                     Name         = 'Clsuter Name'
-                    ResourceType = @{ Name = 'Network Name', DisplayName = 'Network Name' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
                 [PSCustomObject] @{
                     Name         = 'First Data'
-                    ResourceType = @{ Name = 'Physical Disk', DisplayName = 'Physical Disk' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
                 [PSCustomObject] @{
                     Name         = 'Witness'
-                    ResourceType = @{ Name = 'Physical Disk', DisplayName = 'Physical Disk' }
                 } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
             )
         }

--- a/Tests/MSFT_xClusterPreferredOwner.Tests.ps1
+++ b/Tests/MSFT_xClusterPreferredOwner.Tests.ps1
@@ -54,7 +54,6 @@ Describe 'xClusterPreferredOwner' {
                 Name              = 'Resource1'
                 State             = 'Online'
                 OwnerGroup        = 'ClusterGroup1'
-                ResourceType      = @{ Name = 'type1', DisplayName = 'type1' }
             }
         }
 

--- a/Tests/MSFT_xClusterPreferredOwner.Tests.ps1
+++ b/Tests/MSFT_xClusterPreferredOwner.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'xClusterPreferredOwner' {
                 Name              = 'Resource1'
                 State             = 'Online'
                 OwnerGroup        = 'ClusterGroup1'
-                ResourceType      = 'type1'
+                ResourceType      = @{ Name = 'type1', DisplayName = 'type1' }
             }
         }
 


### PR DESCRIPTION
Fix for a bug when searching for the disk in the existing resources

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/16)
<!-- Reviewable:end -->
