### PR TITLE
cmdlet changed as Get-TargetResource fails using Get-ClusterGroup

### DIFF
--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -36,7 +36,7 @@ function Get-TargetResource
             throw "Can't find the cluster $Name"
         }
 
-        $address = Get-ClusterGroup -Cluster $Name -Name "Cluster IP Address" | Get-ClusterParameter "Address"
+        $address = Get-ClusterResource -Cluster $Name -Name "Cluster IP Address" | Get-ClusterParameter "Address"
     }
     finally
     {


### PR DESCRIPTION
I have changed the cmdlet used to get cluster address parameter as in an SQL Availability Group cluster the Get-ClusterGroup cmdlet bombs out.

This is my first ever pull request, so go easy on me :-)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/25)

<!-- Reviewable:end -->
