### PR TITLE
Update xClusterDisk from disk number to guid

### DIFF
--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
@@ -46,7 +46,6 @@ function Get-TargetResource
 function Set-TargetResource
 {
     [CmdletBinding()]
-    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $false)]
@@ -78,7 +77,7 @@ function Set-TargetResource
                 {
                     Write-Verbose "Add the disk '$Guid' to the cluster"
 
-                    Get-ClusterAvailableDisk | Where-Object { $_.Id -eq $Guid } | Add-ClusterDisk
+                    Get-ClusterAvailableDisk | Where-Object { $_.Id -eq $Guid } | Add-ClusterDisk | Out-Null
                 }
                 catch
                 {
@@ -96,7 +95,7 @@ function Set-TargetResource
                     $activeDisk = Get-ClusterActiveDisk | Where-Object { $_.Guid -eq $Guid }
 
                     $activeDisk.Resource.Name = $Label
-                    $activeDisk.Resource.Update()
+                    $activeDisk.Resource.Update() | Out-Null
                 }
                 catch
                 {

--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.schema.mof
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xClusterDisk")]
 class MSFT_xClusterDisk : OMI_BaseResource
 {
-    [Key] String Guid;
-    [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
-    [Write] String Label;
+    [Key, Description("The guid of the cluster disk, also known as disk id or disk signature.")] String Guid;
+    [Write, Description("Define if the cluster disk should be added or removed."), ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
+    [Write, Description("The disk label within the cluster.")] String Label;
 };

--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.schema.mof
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xClusterDisk")]
 class MSFT_xClusterDisk : OMI_BaseResource
 {
-    [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
     [Key] String Guid;
+    [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
     [Write] String Label;
 };

--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.schema.mof
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xClusterDisk")]
 class MSFT_xClusterDisk : OMI_BaseResource
 {
-    [Key] String Number;
     [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
+    [Key] String Guid;
     [Write] String Label;
 };

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### xClusterDisk (Unreleased)
 
-* **Number**: Number of the cluster disk
+* **Guid**: The guid of the cluster disk (aka disk id, disk signature)
 * **Ensure**: Define if the cluster disk should be added (Present) or removed (Absent)
 * **Label**: The disk label inside the Failover Cluster
 
@@ -42,7 +42,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
-* BREAKING CHANGE: Update xClusterDisk from disk number to guid (aka  disk id or disk signature). The disk number is not unique and stable over the cluster nodes, therefore not usable for configuring a cluster with DSC.
+* BREAKING CHANGE: Update xClusterDisk from disk number to guid (aka disk id or disk signature). The disk number is not unique and stable over the cluster nodes, therefore not usable for configuring a cluster with DSC.
 
 ### 1.5.0.0
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### xClusterDisk (Unreleased)
 
-* **Guid**: The guid of the cluster disk (aka disk id, disk signature)
-* **Ensure**: Define if the cluster disk should be added (Present) or removed (Absent)
-* **Label**: The disk label inside the Failover Cluster
+* **Guid**: The guid of the cluster disk, also known as disk id or disk signature.
+* **Ensure**: Define if the cluster disk should be added or removed.
+* **Label**: The disk label within the cluster.
 
 ### xWaitForCluster
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
-* BREAKING CHANGE: Update xClusterDisk from disk number to guid (aka id, signature)
+* BREAKING CHANGE: Update xClusterDisk from disk number to guid (aka  disk id or disk signature). The disk number is not unique and stable over the cluster nodes, therefore not usable for configuring a cluster with DSC.
 
 ### 1.5.0.0
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+* BREAKING CHANGE: Update xClusterDisk from disk number to guid (aka id, signature)
+
 ### 1.5.0.0
 
 * Added xClusterQuorum resource with options *NodeMajority*, *NodeAndDiskMajority*, *NodeAndFileShareMajority*, *DiskOnly*

--- a/Tests/MSFT_xClusterDisk.Tests.ps1
+++ b/Tests/MSFT_xClusterDisk.Tests.ps1
@@ -7,15 +7,21 @@ if (!$PSScriptRoot)
 $RootPath   = (Resolve-Path -Path "$PSScriptRoot\..").Path
 $ModuleName = 'MSFT_xClusterDisk'
 
-try
+if((Get-CimInstance -ClassName 'Win32_OperatingSystem').ProductType -ne 1)
 {
     # For server operating system
-    Add-WindowsFeature -Name RSAT-Clustering-PowerShell -ErrorAction Stop
+    if (-not (Get-WindowsFeature -Name RSAT-Clustering-PowerShell).Installed)
+    {
+        Add-WindowsFeature -Name RSAT-Clustering-PowerShell -ErrorAction Stop
+    }
 }
-catch
+else
 {
     # For client operating system
-    Enable-WindowsOptionalFeature -Online -FeatureName 'RSATClient-Features-Clustering' -ErrorAction Stop
+    if ((Get-WindowsOptionalFeature -Online -FeatureName 'RSATClient-Features-Clustering').State -ne 'Enabled')
+    {
+        Enable-WindowsOptionalFeature -Online -FeatureName 'RSATClient-Features-Clustering' -ErrorAction Stop
+    }
 }
 
 Import-Module (Join-Path -Path $RootPath -ChildPath "DSCResources\$ModuleName\$ModuleName.psm1") -Force

--- a/Tests/MSFT_xClusterDisk.Tests.ps1
+++ b/Tests/MSFT_xClusterDisk.Tests.ps1
@@ -1,9 +1,4 @@
 ﻿
-[CmdletBinding()]
-param
-(
-)
-
 if (!$PSScriptRoot)
 {
     $PSScriptRoot = [System.IO.Path]::GetDirectoryName($MyInvocation.MyCommand.Path)
@@ -12,191 +7,248 @@ if (!$PSScriptRoot)
 $RootPath   = (Resolve-Path -Path "$PSScriptRoot\..").Path
 $ModuleName = 'MSFT_xClusterDisk'
 
-Add-WindowsFeature -Name RSAT-Clustering-PowerShell -ErrorAction SilentlyContinue    
+try
+{
+    # For server operating system
+    Add-WindowsFeature -Name RSAT-Clustering-PowerShell -ErrorAction Stop
+}
+catch
+{
+    # For client operating system
+    Enable-WindowsOptionalFeature -Online -FeatureName 'RSATClient-Features-Clustering' -ErrorAction Stop
+}
 
 Import-Module (Join-Path -Path $RootPath -ChildPath "DSCResources\$ModuleName\$ModuleName.psm1") -Force
-
-
-## General test for the xClusterDisk resource
 
 Describe 'xClusterDisk' {
 
     InModuleScope $ModuleName {
-    
-        $TestParameter = @{
-            Number = 1
-            Ensure = 'Present'
-            Label  = 'First Data'
-        }
 
-        $TestParameter2 = @{
-            Number = 2
-            Ensure = 'Present'
-            Label  = 'Second Data'
-        }
-
-        $TestParameter3 = @{
-            Number = 3
-            Ensure = 'Absent'
-            Label  = 'Third Data'
-        }
-
-        $TestParameter4 = @{
-            Number = 1
-            Ensure = 'Present'
-            Label  = 'Wrong Label'
-        }
-        
-        Mock -CommandName 'Get-CimInstance' -ParameterFilter { $ClassName -eq 'MSCluster_Disk' -and $Namespace -eq 'Root\MSCluster' } -MockWith {
-            switch($Filter)
-            {
-                'Number = 1' {
-                    [PSCustomObject] @{
-                        Name = '1'
-                        Id   = '{0182f270-e2b8-4579-8c0a-176e0e05c30c}'
-                    }                    
-                }
-                default {
-                    $null
-                }
+        Mock Get-ClusterActiveDisk -ModuleName $ModuleName {
+            New-Object -TypeName PSObject -Property @{
+                Guid     = '00000000-0000-0000-0000-000000000001'
+                Label    = 'Cluster Disk 1'
+                Resource = New-Object -TypeName PSObject -Property @{
+                    Name     = 'Cluster Disk 1'
+                } | Add-Member -MemberType ScriptMethod -Name Update -Value { } -PassThru
+            }
+            New-Object -TypeName PSObject -Property @{
+                Guid     = '00000000-0000-0000-0000-000000000002'
+                Label    = 'Witness'
+                Resource = New-Object -TypeName PSObject -Property @{
+                    Name     = 'Witness'
+                } | Add-Member -MemberType ScriptMethod -Name Update -Value { } -PassThru
             }
         }
 
-        Mock -CommandName 'Get-ClusterResource' -MockWith {
-            @(
-                [PSCustomObject] @{
-                    Name         = 'Cluster IP Address'
-                    ResourceType = 'IP Address'
-                } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
-                [PSCustomObject] @{
-                    Name         = 'Clsuter Name'
-                    ResourceType = 'Network Name'
-                } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
-                [PSCustomObject] @{
-                    Name         = 'First Data'
-                    ResourceType = 'Physical Disk'
-                } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
-                [PSCustomObject] @{
-                    Name         = 'Witness'
-                    ResourceType = 'Physical Disk'
-                } | Add-Member -MemberType ScriptMethod -Name Update -Value {} -PassThru
-            )
-        }
-
-        Mock -CommandName 'Get-ClusterParameter' -ParameterFilter { $Name -eq 'DiskIdGuid' } -MockWith {
-            #write-host $args.count -ForegroundColor Cyan
-            #write-host $args -ForegroundColor Cyan
-            switch ($InputObject.Name)
-            {
-                'First Data' {
-                    [PSCustomObject] @{
-                        Value = '{0182f270-e2b8-4579-8c0a-176e0e05c30c}'
-                    }
-                }
-                'Witness' {
-                    [PSCustomObject] @{
-                        Value = '{c8d2cafc-b694-4287-a49d-ed4e87d3d61d}'
-                    }
-                }
-            }
-        }
-        
         Context 'Validate Get-TargetResource method' {
 
-            It 'Returns a [System.Collection.Hashtable] type' {
+            It 'should return a [System.Collection.Hashtable] type' {
 
-                $Result = Get-TargetResource @TestParameter
+                # Arrange
+                $expectedType = 'System.Collections.Hashtable'
 
-                $Result -is [System.Collections.Hashtable] | Should Be $true
+                # Act
+                $result = Get-TargetResource -Guid '00000000-0000-0000-0000-000000000001'
+
+                # Assert
+                $result | Should BeOfType $expectedType
             }
 
-            It 'Returns current configuration' {
+            It 'should return configuration for an present disk (Cluster Disk 1)' {
 
-                $Result = Get-TargetResource @TestParameter
-                
-                $Result.Number | Should Be $TestParameter.Number
-                $Result.Ensure | Should Be $TestParameter.Ensure
-                $Result.Label  | Should Be $TestParameter.Label
-                
-                $Result -is [System.Collections.Hashtable] | Should Be $true
+                # Arrange
+                $expectedEnsure = 'Present'
+                $expectedGuid   = '00000000-0000-0000-0000-000000000001'
+                $expectedLabel  = 'Cluster Disk 1'
+
+                # Act
+                $result = Get-TargetResource -Guid $expectedGuid
+
+                # Assert
+                $result.Guid   | Should Be $expectedGuid
+                $result.Ensure | Should Be $expectedEnsure
+                $result.Label  | Should Be $expectedLabel
             }
 
-            It 'Returns absent for a disk that is absent but should be present' {
+            It 'should return configuration for an present disk (Witness)' {
 
-                $Result = Get-TargetResource @TestParameter2
-                
-                $Result.Number | Should Be $TestParameter2.Number
-                $Result.Ensure | Should Not Be $TestParameter2.Ensure
-                $Result.Label  | Should Not Be $TestParameter2 .Label
-                
-                $Result -is [System.Collections.Hashtable] | Should Be $true
+                # Arrange
+                $expectedEnsure = 'Present'
+                $expectedGuid   = '00000000-0000-0000-0000-000000000002'
+                $expectedLabel  = 'Witness'
+
+                # Act
+                $result = Get-TargetResource -Guid $expectedGuid
+
+                # Assert
+                $result.Guid   | Should Be $expectedGuid
+                $result.Ensure | Should Be $expectedEnsure
+                $result.Label  | Should Be $expectedLabel
             }
-            
-            It 'Returns absent for a disk that is absent as it should be' {
 
-                $Result = Get-TargetResource @TestParameter3
-                
-                $Result.Number | Should Be $TestParameter3.Number
-                $Result.Ensure | Should Be $TestParameter3.Ensure
-                $Result.Label  | Should Be ''
-                
-                $Result -is [System.Collections.Hashtable] | Should Be $true
-            }
-            
-            It 'Returns present for a disk that is present but has the wrong label' {
+            It 'should return configuration for an absent disk' {
 
-                $Result = Get-TargetResource @TestParameter4
-                
-                $Result.Number | Should Be $TestParameter4.Number
-                $Result.Ensure | Should Be $TestParameter4.Ensure
-                $Result.Label  | Should Not Be $TestParameter4.Label
-                
-                $Result -is [System.Collections.Hashtable] | Should Be $true
+                # Arrange
+                $expectedEnsure = 'Absent'
+                $expectedGuid   = '00000000-0000-0000-0000-000000000003'
+
+                # Act
+                $result = Get-TargetResource -Guid $expectedGuid
+
+                # Assert
+                $result.Guid   | Should Be $expectedGuid
+                $result.Ensure | Should Be $expectedEnsure
             }
         }
-        
+
         Context 'Validate Set-TargetResource method' {
 
-            It 'Returns nothing' {
+            Mock Get-ClusterAvailableDisk -ModuleName $ModuleName {
+                New-Object -TypeName PSObject -ArgumentList @{
+                    Name       = 'Cluster Disk 3'
+                    Number     = '3'
+                    Size       = '107374182400'
+                    Id         = '00000000-0000-0000-0000-000000000003'
+                    Cluster    = 'CLUSTER01'
+                    Partitions = @()
+                }
+            }
 
-                $Result = Set-TargetResource @TestParameter
+            Mock Add-ClusterDisk -ModuleName $ModuleName -Verifiable { }
 
-                $Result -eq $null | Should Be $true
+            Mock Remove-ClusterResource -ModuleName $ModuleName -Verifiable { }
+
+            It 'should return a [void] type' {
+
+                # Arrange
+
+                # Act
+                $result = Set-TargetResource -Guid '00000000-0000-0000-0000-000000000001'
+
+                # Assert
+                $result | Should BeNullOrEmpty
+            }
+
+            It 'should add a new disk to the cluster' {
+
+                # Arrange
+                $actualEnsure = 'Present'
+                $actualGuid   = '00000000-0000-0000-0000-000000000003'
+
+                # Act
+                $result = Set-TargetResource -Ensure $actualEnsure -Guid $actualGuid
+
+                # Assert
+                Assert-MockCalled Add-ClusterDisk -Exactly 1 -Scope It
+            }
+
+            It 'should remove an existing disk from the cluster' {
+
+                # Arrange
+                $actualEnsure = 'Absent'
+                $actualGuid   = '00000000-0000-0000-0000-000000000001'
+
+                # Act
+                $result = Set-TargetResource -Ensure $actualEnsure -Guid $actualGuid
+
+                # Assert
+                Assert-MockCalled Remove-ClusterResource -Exactly 1 -Scope It
             }
         }
-        
+
         Context 'Validate Test-TargetResource method' {
 
-            It 'Check present disk that is present returns $true' {
+            It 'should return a [System.Boolean] type' {
 
-                $Result = Test-TargetResource -Ensure $TestParameter.Ensure -Label $TestParameter.Label -Number $TestParameter.Number
+                # Arrange
+                $expectedType = 'System.Boolean'
 
-                $Result -is [System.Boolean] | Should Be $true
-                $Result | Should Be $true
+                # Act
+                $result = Test-TargetResource -Guid '00000000-0000-0000-0000-000000000001'
+
+                # Assert
+                $result | Should BeOfType $expectedType
             }
-            
-            It 'Check absent disk that should be present returns $false' {
 
-                $Result = Test-TargetResource -Ensure $TestParameter2.Ensure -Label $TestParameter2.Label -Number $TestParameter2.Number
+            It 'should return $true for a desired present disk' {
 
-                $Result -is [System.Boolean] | Should Be $true
-                $Result | Should Be $false
+                # Arrange
+                $actualEnsure = 'Present'
+                $actualGuid   = '00000000-0000-0000-0000-000000000001'
+
+                # Act
+                $result = Test-TargetResource -Ensure $actualEnsure -Guid $actualGuid
+
+                # Assert
+                $result | Should Be $true
             }
-            
-            It 'Check absent disk that is absent returns $true' {
 
-                $Result = Test-TargetResource -Ensure $TestParameter3.Ensure -Label $TestParameter3.Label -Number $TestParameter3.Number
+            It 'should return $true for a desired absent disk' {
 
-                $Result -is [System.Boolean] | Should Be $true
-                $Result | Should Be $true
+                # Arrange
+                $actualEnsure = 'Absent'
+                $actualGuid   = '00000000-0000-0000-0000-000000000003'
+
+                # Act
+                $result = Test-TargetResource -Ensure $actualEnsure -Guid $actualGuid
+
+                # Assert
+                $result | Should Be $true
             }
-            
-            It 'Check that present disk but with a wrong label returns $false' {
 
-                $Result = Test-TargetResource -Ensure $TestParameter4.Ensure -Label $TestParameter4.Label -Number $TestParameter4.Number
+            It 'should return $false for a disk which is absent but should be present' {
 
-                $Result -is [System.Boolean] | Should Be $true
-                $Result | Should Be $false
+                # Arrange
+                $actualEnsure = 'Present'
+                $actualGuid   = '00000000-0000-0000-0000-000000000003'
+
+                # Act
+                $result = Test-TargetResource -Ensure $actualEnsure -Guid $actualGuid
+
+                # Assert
+                $result | Should Be $false
+            }
+
+            It 'should return $false for a disk which is present but should be absent' {
+
+                # Arrange
+                $actualEnsure = 'Absent'
+                $actualGuid   = '00000000-0000-0000-0000-000000000002'
+
+                # Act
+                $result = Test-TargetResource -Ensure $actualEnsure -Guid $actualGuid
+
+                # Assert
+                $result | Should Be $false
+            }
+
+            It 'should return $true for a matching label' {
+
+                # Arrange
+                $actualEnsure = 'Present'
+                $actualGuid   = '00000000-0000-0000-0000-000000000002'
+                $actualLabel  = 'Witness'
+
+                # Act
+                $result = Test-TargetResource -Ensure $actualEnsure -Guid $actualGuid -Label $actualLabel
+
+                # Assert
+                $result | Should Be $true
+            }
+
+            It 'should return $false for a incorrect label' {
+
+                # Arrange
+                $actualEnsure = 'Present'
+                $actualGuid   = '00000000-0000-0000-0000-000000000002'
+                $actualLabel  = 'Cluster Disk 2'
+
+                # Act
+                $result = Test-TargetResource -Ensure $actualEnsure -Guid $actualGuid -Label $actualLabel
+
+                # Assert
+                $result | Should Be $false
             }
         }
     }


### PR DESCRIPTION
Hi

I've tried to use the xClusterDisk resource on a target system, where the disk numbers are not matching and are reused multiple times, because the cluster has attached local dedicated SAN disks as well as shares clustered SAN disks. As a conclusion, the disk number cannot be used as a identifier for the cluster disk - it's just not working in every case.

Therefore, I've reworked the resource to now use the disks id (aka guid, signature) for identification. Tests have been reworked too.

Because we are changing a key property in the MOF, this will be a breaking change.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/26)

<!-- Reviewable:end -->
