### PR TITLE
Removed endless while loop

### DIFF
--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -104,9 +104,12 @@ function Set-TargetResource
         {
             Write-Verbose -Message "Cluster $Name is NOT present"
 
-            New-Cluster -Name $Name -Node $env:COMPUTERNAME -StaticAddress $StaticIPAddress -NoStorage -Force
+            New-Cluster -Name $Name -Node $env:COMPUTERNAME -StaticAddress $StaticIPAddress -NoStorage -Force -ErrorAction Stop
 
-            While (!(Get-Cluster)){Start-Sleep 5}
+            if(!(Get-Cluster))
+            {
+                throw "Cluster creation failed. Please verify output of 'Get-Cluster' command"
+            }
 
             Write-Verbose -Message "Created Cluster $Name"
         }


### PR DESCRIPTION
If during the 'Set-TargetResource' a new cluster is being created, but the 'New-Cluster' command does not end successfully. Then the 'while' loop was running forever keeping the LCM in a busy state.

I noticed the problem when creating a cluster but the CNO already existed in AD and was linked to a previously created cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/30)
<!-- Reviewable:end -->
