### PR TITLE
xFailOverCluster: Updating README.md, adding CHANGELOG.md, adding GitHub templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+If you'd like to contribute to this project, please review the [Contribution Guidelines](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,13 @@
+<!--
+Your feedback and support is greatly appreciated, thanks for contributing!
+
+Please prefix the issue title with the resource name, i.e. 'xCluster: Short description of my issue'
+Please provide the following information regarding your issue (place N/A if the fields that don't apply to your issue):
+-->
+**Details of the scenario you tried and the problem that is occurring:**
+
+**The DSC configuration that is using the resource (as detailed as possible):**
+
+**Version of the Operating System and PowerShell the DSC Target Node is running:**
+
+**Version of the DSC module you're using, or 'dev' if you're using current dev branch:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!
+
+Please prefix the PR title with the resource name, i.e. 'xCluster: My short description'
+If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xCluster: My short description'
+
+To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
+Change to [x] for each task in the task list that applies to this PR.
+-->
+**Pull Request (PR) description**
+<!-- Replace this with a description of your pull request -->
+
+**This Pull Request (PR) fixes the following issues:**
+<!-- Replace this with the list of issues or n/a. Use format: Fixes #123 -->
+
+**Task list:**
+- [ ] Change details added to Unreleased section of CHANGELOG.md?
+- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
+- [ ] Examples appropriately updated?
+- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
+- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
   - Removed 'Unreleased' "tag" from the resources xClusterQuorum and xClusterDisk (issue #36)
   - Added new sections to each resource (Requirements, Parameters and Examples) in the README.md. Some does not yet have any examples, so they are set to 'None.'.
   - Added GitHub templates PULL\_REQUEST\_TEMPLATE, ISSUE_TEMPLATE and CONTRIBUTING.md (issue #45).
-  - Split the change log from README.md to a seperate file CHANGELOG.md.
+  - Split the change log from README.md to a seperate file CHANGELOG.md (issue #48).
+  - Added the resource xClusterPreferredOwner to README.md (issue #51).
+  - Added the resource xClusterNetwork to README.md (issue #56).
 
 ### 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Change log for xFailOverCluster
+
+## Unreleased
+
+- Changes to xFailOverCluster
+  - Added 'Code of Conduct' text to the README.md (issue #44).
+  - Added TOC for all resources in the README.md (issue #43).
+  - Fixed typos and lint errors in README.md.
+  - Fixed style issue in example in README.md.
+  - Removed 'Unreleased' "tag" from the resources xClusterQuorum and xClusterDisk (issue #36)
+  - Added new sections to each resource (Requirements, Parameters and Examples) in the README.md. Some does not yet have any examples, so they are set to 'None.'.
+  - Added GitHub templates PULL\_REQUEST\_TEMPLATE, ISSUE_TEMPLATE and CONTRIBUTING.md (issue #45).
+  - Split the change log from README.md to a seperate file CHANGELOG.md.
+
+### 1.6.0.0
+
+- xCluster: Fixed bug in which failure to create a new cluster would hang
+
+### 1.5.0.0
+
+- Added xClusterQuorum resource with options *NodeMajority*, *NodeAndDiskMajority*, *NodeAndFileShareMajority*, *DiskOnly*
+- Currently does not implement cloud witness for Windows 2016.
+- Added xClusterDisk resource
+
+### 1.2.0.0
+
+- xCluster: Added -NoStorage switch to Add-ClusterNode. This prevents disks from being automatically added when joining a node to a cluster
+
+### 1.1.0.0
+
+- Removed requirement for CredSSP
+
+### 1.0.0.0
+
+- Initial release with the following resources:
+  - xCluster and xWaitForCluster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   - Split the change log from README.md to a seperate file CHANGELOG.md (issue #48).
   - Added the resource xClusterPreferredOwner to README.md (issue #51).
   - Added the resource xClusterNetwork to README.md (issue #56).
+  - Removed Credential parameter from parameter list for xWaitForCluster. Parameter Credential does not exist in the schema.mof of the resource (issue #62).
+  - Now all parameters in the README.md list their data type and type qualifier (issue #58.)
+  - Added Import-DscResource to example in README.md.
 
 ### 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Changes to xClusterPreferredOwner
+  - Script Analyzer warnings have been fixed (issue #50). This also failed the tests for the resource.
+- Changes to xClusterDisk
+  - Fixed test that was failing in  AppVeyor (issue #55).
 - Changes to xFailOverCluster
   - Added 'Code of Conduct' text to the README.md (issue #44).
   - Added TOC for all resources in the README.md (issue #43).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Ensures that a group of machines form a cluster.
 
 #### Examples
 
-[Cluster example](#clusterexample)
+[Cluster example](#cluster-example)
 
 ### xClusterDisk
 
@@ -146,7 +146,7 @@ Ensures that a node waits for a remote cluster is created.
 
 #### Examples
 
-[Cluster example](#clusterexample)
+[Cluster example](#cluster-example)
 
 ## xFailOverCluster Examples
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ A full list of changes in each version can be found in the [change log](CHANGELO
 ## Resources
 
 * [**xCluster**](#xcluster) Ensures that a group of machines form a cluster.
-* [**xClusterQuorum**](#xclusterquorum) Configures quorum in a cluster.
 * [**xClusterDisk**](#xclusterdisk) Configures shared disks in a cluster.
+* [**xClusterPreferredOwner**](#xclusterpreferredowner) Configures preferred owner of a cluster group in a cluster.
+* [**xClusterQuorum**](#xclusterquorum) Configures quorum in a cluster.
 * [**xWaitForCluster**](#xwaitforcluster) Ensures that a node waits for a remote cluster is created.
 
 ### xCluster
@@ -40,35 +41,17 @@ Ensures that a group of machines form a cluster.
 
 #### Requirements
 
-* Target machine must be running Windows Server 2008 R2 or later
+* Target machine must be running Windows Server 2008 R2 or later.
 
 #### Parameters
 
-* **Name**: Name of the cluster
-* **StaticIPAddress**: Static IP Address of the cluster
-* **DomainAdministratorCredential**: Credential used to create the cluster
+* **Name**: Name of the cluster.
+* **StaticIPAddress**: Static IP Address of the cluster.
+* **DomainAdministratorCredential**: Credential used to create the cluster.
 
 #### Examples
 
 [Cluster example](#clusterexample)
-
-### xClusterQuorum
-
-Configures quorum in a cluster.
-
-#### Requirements
-
-* Target machine must be running Windows Server 2008 R2 or later
-
-#### Parameters
-
-* **IsSingleInstance** Always set to `Yes` to prevent multiple quorum settings per cluster.
-* **Type** Quorum type to use: *NodeMajority*, *NodeAndDiskMajority*, *NodeAndFileShareMajority*, *DiskOnly*
-* **Resource** The name of the disk or file share resource to use as witness. Is optional with *NodeMajority* type.
-
-#### Examples
-
-None.
 
 ### xClusterDisk
 
@@ -76,13 +59,71 @@ Configures shared disks in a cluster.
 
 #### Requirements
 
-* Target machine must be running Windows Server 2008 R2 or later
+* Target machine must be running Windows Server 2008 R2 or later.
 
 #### Parameters
 
-* **Number**: Number of the cluster disk
-* **Ensure**: Define if the cluster disk should be added (Present) or removed (Absent)
-* **Label**: The disk label inside the Failover Cluster
+* **Number**: Number of the cluster disk.
+* **Ensure**: Define if the cluster disk should be added (Present) or removed (Absent).
+* **Label**: The disk label inside the Failover Cluster.
+
+#### Examples
+
+None.
+
+### xClusterNetwork
+
+Configures preferred owners of a cluster group in a cluster.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later.
+
+#### Parameters
+
+* **[String] Address** _(Key)_: None.
+* **[String] AddressMask** _(Key)_: None.
+* **[String] Name** _(Write)_: None.
+* **[String] Role** _(Write)_: None. { 0 | 1 | 3 }
+* **[String] Metric** _(Write)_: None.
+
+#### Examples
+
+None.
+
+### xClusterPreferredOwner
+
+Configures preferred owners of a cluster group in a cluster.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later.
+
+#### Parameters
+
+* **[String] ClusterGroup** _(Key)_: Name of the cluster group.
+* **[String] ClusterName** _(Key)_: Name of the cluster.
+* **[String[]] Nodes** _(Required)_: The nodes to set as owners.
+* **[String[]] ClusterResources** _(Write)_: The resources to set preferred owner on.
+* **[String] Ensure** _(Write)_: If the preferred owners should be present or absent. { *Present* | Absent }
+
+#### Examples
+
+None.
+
+### xClusterQuorum
+
+Configures quorum in a cluster.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later.
+
+#### Parameters
+
+* **IsSingleInstance** Always set to `Yes` to prevent multiple quorum settings per cluster.
+* **Type** Quorum type to use: *NodeMajority*, *NodeAndDiskMajority*, *NodeAndFileShareMajority*, *DiskOnly*.
+* **Resource** The name of the disk or file share resource to use as witness. Is optional with *NodeMajority* type.
 
 #### Examples
 
@@ -94,14 +135,14 @@ Ensures that a node waits for a remote cluster is created.
 
 #### Requirements
 
-* Target machine must be running Windows Server 2008 R2 or later
+* Target machine must be running Windows Server 2008 R2 or later.
 
 #### Parameters
 
-* **Name**: Name of the cluster to wait for
-* **RetryIntervalSec**: Interval to check for cluster existence
-* **RetryCount**: Maximum number of retries to check for cluster existance
-* **Credential**: Credential used to join or leave domain
+* **Name**: Name of the cluster to wait for.
+* **RetryIntervalSec**: Interval to check for cluster existence.
+* **RetryCount**: Maximum number of retries to check for cluster existence.
+* **Credential**: Credential used to join or leave domain.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -1,76 +1,113 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/6a59vfritv4kbc7d/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xfailovercluster/branch/master)
-
 # xFailOverCluster
 
-The **xFailOverCluster** DSC modules contains **xCluster** and **xWaitForCluster** resources for creating and configuring failover clusters.
+The **xFailOverCluster** module contains DSC resources for deployment and configuration of Failover Clustering.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Branches
+
+### master
+
+[![Build status](https://ci.appveyor.com/api/projects/status/6a59vfritv4kbc7d/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xfailovercluster/branch/master)
+
+This is the branch containing the latest release - no contributions should be made directly to this branch.
+
+### dev
+
+[![Build status](https://ci.appveyor.com/api/projects/status/6a59vfritv4kbc7d/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xfailovercluster/branch/dev)
+
+This is the development branch to which contributions should be proposed by contributors as pull requests. This development branch will periodically be merged to the master branch, and be released to [PowerShell Gallery](https://www.powershellgallery.com/).
 
 ## Contributing
+
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
+## Change log
+
+A full list of changes in each version can be found in the [change log](CHANGELOG.md).
 
 ## Resources
 
-* **xCluster** ensures that a group of machines form a cluster.
-* **xWaitForCluster** ensures that a node waits for a remote cluster is created.
+* [**xCluster**](#xcluster) Ensures that a group of machines form a cluster.
+* [**xClusterQuorum**](#xclusterquorum) Configures quorum in a cluster.
+* [**xClusterDisk**](#xclusterdisk) Configures shared disks in a cluster.
+* [**xWaitForCluster**](#xwaitforcluster) Ensures that a node waits for a remote cluster is created.
 
 ### xCluster
+
+Ensures that a group of machines form a cluster.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later
+
+#### Parameters
 
 * **Name**: Name of the cluster
 * **StaticIPAddress**: Static IP Address of the cluster
 * **DomainAdministratorCredential**: Credential used to create the cluster
 
-### xClusterQuorum (Unreleased)
+#### Examples
+
+[Cluster example](#clusterexample)
+
+### xClusterQuorum
+
+Configures quorum in a cluster.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later
+
+#### Parameters
 
 * **IsSingleInstance** Always set to `Yes` to prevent multiple quorum settings per cluster.
 * **Type** Quorum type to use: *NodeMajority*, *NodeAndDiskMajority*, *NodeAndFileShareMajority*, *DiskOnly*
 * **Resource** The name of the disk or file share resource to use as witness. Is optional with *NodeMajority* type.
 
-### xClusterDisk (Unreleased)
+#### Examples
+
+None.
+
+### xClusterDisk
+
+Configures shared disks in a cluster.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later
+
+#### Parameters
 
 * **Number**: Number of the cluster disk
 * **Ensure**: Define if the cluster disk should be added (Present) or removed (Absent)
 * **Label**: The disk label inside the Failover Cluster
 
+#### Examples
+
+None.
+
 ### xWaitForCluster
+
+Ensures that a node waits for a remote cluster is created.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later
+
+#### Parameters
 
 * **Name**: Name of the cluster to wait for
 * **RetryIntervalSec**: Interval to check for cluster existence
 * **RetryCount**: Maximum number of retries to check for cluster existance
 * **Credential**: Credential used to join or leave domain
 
-## Versions
+#### Examples
 
-### Unreleased
+[Cluster example](#clusterexample)
 
-* Changes to xClusterPreferredOwner
-  * Script Analyzer warnings have been fixed (issue #50). This also failed the tests for the resource.
-* Changes to xClusterDisk
-  * Fixed test that was failing in  AppVeyor (issue #55).
-
-### 1.6.0.0
-
-* xCluster: Fixed bug in which failure to create a new cluster would hang
-
-### 1.5.0.0
-
-* Added xClusterQuorum resource with options *NodeMajority*, *NodeAndDiskMajority*, *NodeAndFileShareMajority*, *DiskOnly*
-* Currently does not implement cloudwitness for Windows 2016.
-* Added xClusterDisk resource
-
-### 1.2.0.0
-
-* xCluster: Added -NoStorage switch to add-clusterNode. This prevents disks from being automatically added when joining a node to a cluster
-
-### 1.1.0.0
-
-* Removed requirement for CredSSP
-
-### 1.0.0.0
-
-* Initial release with the following resources:
-    - xCluster and xWaitForCluster
-
-## Examples
+## xFailOverCluster Examples
 
 ### Cluster example
 
@@ -83,67 +120,71 @@ For an example of an end to end scenario, check out the SQL HA Group blog post o
 ```powershell
 Configuration ClusterDemo
 {
-    param([Parameter(Mandatory=$true)]
-          [ValidateNotNullorEmpty()]
-          [PsCredential] $domainAdminCred)
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]
+        $domainAdminCredential
+    )
 
-    Node $AllNodes.Where{$_.Role -eq "PrimaryClusterNode" }.NodeName
+    Node $AllNodes.Where{$_.Role -eq 'PrimaryClusterNode' }.NodeName
     {
         WindowsFeature FailoverFeature
         {
-            Ensure = "Present"
-            Name      = "Failover-clustering"
+            Ensure = 'Present'
+            Name   = 'Failover-clustering'
         }
 
         WindowsFeature RSATClusteringPowerShell
         {
-            Ensure = "Present"
-            Name   = "RSAT-Clustering-PowerShell"
+            Ensure = 'Present'
+            Name   = 'RSAT-Clustering-PowerShell'
 
-            DependsOn = "[WindowsFeature]FailoverFeature"
+            DependsOn = '[WindowsFeature]FailoverFeature'
         }
 
         WindowsFeature RSATClusteringCmdInterface
         {
-            Ensure = "Present"
-            Name   = "RSAT-Clustering-CmdInterface"
+            Ensure = 'Present'
+            Name   = 'RSAT-Clustering-CmdInterface'
 
-            DependsOn = "[WindowsFeature]RSATClusteringPowerShell"
+            DependsOn = '[WindowsFeature]RSATClusteringPowerShell'
         }
 
         xCluster ensureCreated
         {
             Name = $Node.ClusterName
             StaticIPAddress = $Node.ClusterIPAddress
-            DomainAdministratorCredential = $domainAdminCred
+            DomainAdministratorCredential = $domainAdminCredential
 
            DependsOn = “[WindowsFeature]RSATClusteringCmdInterface”
        }
 
     }
 
-    Node $AllNodes.Where{ $_.Role -eq "ReplicaServerNode" }.NodeName
+    Node $AllNodes.Where{ $_.Role -eq 'ReplicaServerNode' }.NodeName
     {
         WindowsFeature FailoverFeature
         {
-            Ensure = "Present"
-            Name      = "Failover-clustering"
+            Ensure = 'Present'
+            Name      = 'Failover-clustering'
         }
 
         WindowsFeature RSATClusteringPowerShell
         {
-            Ensure = "Present"
-            Name   = "RSAT-Clustering-PowerShell"
+            Ensure = 'Present'
+            Name   = 'RSAT-Clustering-PowerShell'
 
-            DependsOn = "[WindowsFeature]FailoverFeature"
+            DependsOn = '[WindowsFeature]FailoverFeature'
         }
 
         WindowsFeature RSATClusteringCmdInterface
         {
-            Ensure = "Present"
-            Name   = "RSAT-Clustering-CmdInterface"
+            Ensure = 'Present'
+            Name   = 'RSAT-Clustering-CmdInterface'
 
-            DependsOn = "[WindowsFeature]RSATClusteringPowerShell"
+            DependsOn = '[WindowsFeature]RSATClusteringPowerShell'
         }
 
         xWaitForCluster waitForCluster
@@ -152,18 +193,17 @@ Configuration ClusterDemo
             RetryIntervalSec = 10
             RetryCount = 60
 
-            DependsOn = “[WindowsFeature]RSATClusteringCmdInterface”
+            DependsOn = '[WindowsFeature]RSATClusteringCmdInterface'
         }
 
         xCluster joinCluster
         {
             Name = $Node.ClusterName
             StaticIPAddress = $Node.ClusterIPAddress
-            DomainAdministratorCredential = $domainAdminCred
+            DomainAdministratorCredential = $domainAdminCredential
 
-            DependsOn = "[xWaitForCluster]waitForCluster"
+            DependsOn = '[xWaitForCluster]waitForCluster'
         }
-
     }
 }
 
@@ -171,31 +211,31 @@ $ConfigData = @{
     AllNodes = @(
 
         @{
-            NodeName= "*"
+            NodeName= '*'
 
-            CertificateFile = "C:\keys\Dscdemo.cer"                 # use your own certificate
+            CertificateFile = 'C:\keys\Dscdemo.cer'                 # use your own certificate
             Thumbprint = "E513EEFCB763E6954C52BA66A1A81231BF3F551E" # assume both machines have the same certificate to hold private key
                                                                     # replace the value of thumbprint with your own.
 
-            ClusterName = "Cluster"
-            ClusterIPAddress = "192.168.100.20/24"    # replace the ipaddress of your own.
+            ClusterName = 'Cluster'
+            ClusterIPAddress = '192.168.100.20/24'    # replace the ip address of your own.
         },
 
          # Node01
         @{
-            NodeName= "Node01"   # rename to actual machine name of VM
-            Role = "PrimaryClusterNode"
+            NodeName= 'Node01'   # rename to actual machine name of VM
+            Role = 'PrimaryClusterNode'
          },
 
          # Node02
          @{
-            NodeName= "Node02"   # rename to actual machine name of VM
-            Role = "ReplicaServerNode"
+            NodeName= 'Node02'   # rename to actual machine name of VM
+            Role = 'ReplicaServerNode'
          }
-    );
+    )
 }
 
-$domainAdminCred = Get-Credential -UserName "ClusterDemo\Administrator" -Message "Enter password for private domain Administrator"
+$domainAdminCred = Get-Credential -UserName 'ClusterDemo\Administrator' -Message 'Enter password for private domain Administrator'
 
-ClusterDemo -ConfigurationData $ConfigData -domainAdminCred $domainAdminCred
+ClusterDemo -ConfigurationData $ConfigData -domainAdminCred $domainAdminCredential
 ```


### PR DESCRIPTION
- Changes to xFailOverCluster
  - Added 'Code of Conduct' text to the README.md (issue #44).
  - Added TOC for all resources in the README.md (issue #43).
  - Fixed typos and lint errors in README.md.
  - Fixed style issue in example in README.md.
  - Removed 'Unreleased' "tag" from the resources xClusterQuorum and xClusterDisk (issue #36)
  - Added new sections to each resource (Requirements, Parameters and Examples) in the README.md. Some does not yet have any examples, so they are set to 'None.'.
  - Added GitHub templates PULL\_REQUEST\_TEMPLATE, ISSUE_TEMPLATE and CONTRIBUTING.md (issue #45).
  - Split the change log from README.md to a seperate file CHANGELOG.md (issue #48).
  - Added the resource xClusterPreferredOwner to README.md (issue #51).
  - Added the resource xClusterNetwork to README.md (issue #56).
  - Removed Credential parameter from parameter list for xWaitForCluster. Parameter Credential does not exist in the schema.mof of the resource (issue #62).
  - Now all parameters in the README.md list their data type and type qualifier (issue #58.)
  - Added Import-DscResource to example in README.md.


Fixes #44 
Fixes #43 
Fixes #36 
Fixes #45 
Fixes #48 
Fixes #51 
Fixes #56
Fixes #62 
Fixes #58 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/60)
<!-- Reviewable:end -->
