### PR TITLE
xFailOverCluster: Added VS Code workspace settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ﻿DSCResource.Tests
 .vs
+.vscode
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 ﻿DSCResource.Tests
 .vs
-.vscode
 node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "powershell.codeFormatting.whitespaceAroundOperator": true,
     "powershell.codeFormatting.whitespaceAfterSeparator": true,
     "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "powershell.codeFormatting.preset": "Custom",
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
-// Place your settings in this file to overwrite default and user settings.
 {
     "powershell.codeFormatting.openBraceOnSameLine": false,
     "powershell.codeFormatting.newLineAfterOpenBrace": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "powershell.codeFormatting.openBraceOnSameLine": false,
+    "powershell.codeFormatting.newLineAfterOpenBrace": false,
+    "powershell.codeFormatting.newLineAfterCloseBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": true,
+    "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
     correctly 'ISSUE\_TEMPLATE.md'.
   - Changed appveyor.yml to use the new default test framework in the AppVeyor
     module in DscResource.Tests (AppVeyor.psm1).
+  - Added VS Code workspace settings file with formatting settings matching the
+    Style Guideline (issue #67). That will make it possible inside VS Code to
+    press SHIFT+ALT+F, or press F1 and choose 'Format document' in the list. The
+    PowerShell code will then be formatted according to the Style Guideline
+    (although maybe not complete, but would help a long way).
 - Changes to xCluster
   - Added examples
     - 1-CreateFirstNodeOfAFailoverCluster.ps1


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xFailOverCluster
  - Added VS Code workspace settings file with formatting settings matching the
    Style Guideline (issue #67). That will make it possible inside VS Code to
    press SHIFT+ALT+F, or press F1 and choose 'Format document' in the list. The
    PowerShell code will then be formatted according to the Style Guideline
    (although maybe not complete, but would help a long way).

**This Pull Request (PR) fixes the following issues:**
Fixes #67 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/68)
<!-- Reviewable:end -->
