### PR TITLE
xFailOverCluster: Switch build worker in AppVeyor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
   - Added a script file (Tests\Unit\Stubs\Write-ModuleStubFile.ps1) to be able
     to rebuild the stub file (FailoverClusters.stubs.psm1) whenever needed.
   - Added code block around types in README.md.
+  - Switched AppVoyer build worker to Visual Studio 2017 (Windows Server 2016).
 - Changes to xCluster
   - Added examples
     - 1-CreateFirstNodeOfAFailoverCluster.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 #---------------------------------#
 #      environment configuration  #
 #---------------------------------#
+image: Visual Studio 2017
 version: 1.6.{build}.0
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xFailOverCluster
  - Switched AppVoyer build worker to Visual Studio 2017 (Windows Server 2016).

**This Pull Request (PR) fixes the following issues:**
This is a workaround for the common test not running due to a bug in DscResource.Tests.
Using a build worker with newer WMF version enable common tests to run again.

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/99)
<!-- Reviewable:end -->
