### PR TITLE
xWaitForCluster: Added unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,14 @@
   - Added example ([issue #57](https://github.com/PowerShell/xFailOverCluster/issues/57))
     - 1-ChangeClusterNetwork.ps1
   - Added links to examples from README.md.
+- Changes to xWaitForCluster
+  - Refactored the unit test for this resource to use stubs and increase coverage
+    (issue #78).
+  - Now the Test-TargetResource correctly returns false if the domain namn cannot
+    be evaluated  (issue #107).
+  - Added example
+    - 1-WaitForFailoverClusterToBePresent.ps1
+  - Added link to example from README.md
 
 ### 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@
     Get-CimInstance ([issue #49](https://github.com/PowerShell/xFailOverCluster/issues/49)).
 - Changes to xWaitForCluster
   - Refactored the unit test for this resource to use stubs and increase coverage
-    (issue #78).
+    ([issue #78](https://github.com/PowerShell/xFailOverCluster/issues/78)).
   - Now the Test-TargetResource correctly returns false if the domain namn cannot
-    be evaluated  (issue #107).
+    be evaluated  ([issue #107](https://github.com/PowerShell/xFailOverCluster/issues/107)).
   - Changed the code to be more aligned with the style guideline.
   - Updated parameter description in the schema.mof.
-  - Resolved Script Analyzer warnings (issue #54).
+  - Resolved Script Analyzer warnings ([issue #54](https://github.com/PowerShell/xFailOverCluster/issues/54)).
 
 ## 1.7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@
 - Changes to xCluster
   - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
     Get-CimInstance ([issue #49](https://github.com/PowerShell/xFailOverCluster/issues/49)).
+    Minor style change in tests. Removed '-' infront of '-Be', '-Not', '-Throw', etc.
 - Changes to xWaitForCluster
   - Refactored the unit test for this resource to use stubs and increase coverage
     ([issue #78](https://github.com/PowerShell/xFailOverCluster/issues/78)).
-  - Now the Test-TargetResource correctly returns false if the domain namn cannot
+  - Now the Test-TargetResource correctly returns false if the domain name cannot
     be evaluated  ([issue #107](https://github.com/PowerShell/xFailOverCluster/issues/107)).
   - Changed the code to be more aligned with the style guideline.
   - Updated parameter description in the schema.mof.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
 - Changes to xCluster
   - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
     Get-CimInstance ([issue #49](https://github.com/PowerShell/xFailOverCluster/issues/49)).
+- Changes to xWaitForCluster
+  - Refactored the unit test for this resource to use stubs and increase coverage
+    (issue #78).
+  - Now the Test-TargetResource correctly returns false if the domain namn cannot
+    be evaluated  (issue #107).
+  - Changed the code to be more aligned with the style guideline.
+  - Updated parameter description in the schema.mof.
+  - Resolved Script Analyzer warnings (issue #54).
 
 ## 1.7.0.0
 
@@ -118,17 +126,6 @@
   - Added example ([issue #57](https://github.com/PowerShell/xFailOverCluster/issues/57))
     - 1-ChangeClusterNetwork.ps1
   - Added links to examples from README.md.
-- Changes to xWaitForCluster
-  - Refactored the unit test for this resource to use stubs and increase coverage
-    (issue #78).
-  - Now the Test-TargetResource correctly returns false if the domain namn cannot
-    be evaluated  (issue #107).
-  - Changed the code to be more aligned with the style guideline.
-  - Updated parameter description in the schema.mof.
-  - Added example
-    - 1-WaitForFailoverClusterToBePresent.ps1
-  - Added link to example from README.md
-  - Resolved Script Analyzer warnings (issue #54).
 
 ### 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,9 +123,12 @@
     (issue #78).
   - Now the Test-TargetResource correctly returns false if the domain namn cannot
     be evaluated  (issue #107).
+  - Changed the code to be more aligned with the style guideline.
+  - Updated parameter description in the schema.mof.
   - Added example
     - 1-WaitForFailoverClusterToBePresent.ps1
   - Added link to example from README.md
+  - Resolved Script Analyzer warnings (issue #54).
 
 ### 1.6.0.0
 

--- a/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.psm1
+++ b/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.psm1
@@ -1,7 +1,7 @@
 #
 # xWaitForCluster: DSC Resource that will wait for given name of Cluster, it checks the state of the cluster for given # interval until the cluster is found or the number of retries is reached.
 #
-# 
+#
 
 
 #
@@ -11,7 +11,7 @@ function Get-TargetResource
 {
     [OutputType([Hashtable])]
     param
-    (    
+    (
         [parameter(Mandatory)][string] $Name,
 
         [UInt64] $RetryIntervalSec = 10,
@@ -31,7 +31,7 @@ function Get-TargetResource
 function Set-TargetResource
 {
     param
-    (    
+    (
         [parameter(Mandatory)][string] $Name,
 
         [UInt64] $RetryIntervalSec = 10,
@@ -61,13 +61,13 @@ function Set-TargetResource
 
                 break;
             }
-            
+
         }
         catch
         {
              Write-Verbose -Message "Cluster $Name not found. Will retry again after $RetryIntervalSec sec"
         }
-            
+
         Write-Verbose -Message "Cluster $Name not found. Will retry again after $RetryIntervalSec sec"
         Start-Sleep -Seconds $RetryIntervalSec
     }
@@ -85,7 +85,7 @@ function Test-TargetResource
 {
     [OutputType([Boolean])]
     param
-    (    
+    (
         [parameter(Mandatory)][string] $Name,
 
         [UInt64] $RetryIntervalSec = 10,
@@ -102,17 +102,19 @@ function Test-TargetResource
             Write-Verbose -Message "Can't find machine's domain name"
             $false
         }
-
-        $cluster = Get-Cluster -Name $Name -Domain $ComputerInfo.Domain
-        if ($cluster -eq $null)
-        {
-            Write-Verbose -Message "Cluster $Name not found in domain $ComputerInfo.Domain"
-            $false
-        }
         else
         {
-            Write-Verbose -Message "Found cluster $Name"
-            $true
+            $cluster = Get-Cluster -Name $Name -Domain $ComputerInfo.Domain
+            if ($cluster -eq $null)
+            {
+                Write-Verbose -Message "Cluster $Name not found in domain $ComputerInfo.Domain"
+                $false
+            }
+            else
+            {
+                Write-Verbose -Message "Found cluster $Name"
+                $true
+            }
         }
     }
     catch

--- a/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.psm1
+++ b/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.psm1
@@ -77,7 +77,7 @@ function Set-TargetResource
     {
         try
         {
-            $computerObject = Get-CimInstance -Class Win32_ComputerSystem
+            $computerObject = Get-CimInstance -ClassName Win32_ComputerSystem
             if ($null -eq $computerObject -or $null -eq $computerObject.Domain)
             {
                 Write-Verbose -Message "Can't find machine's domain name"
@@ -146,7 +146,7 @@ function Test-TargetResource
 
     try
     {
-        $computerObject = Get-CimInstance -Class Win32_ComputerSystem
+        $computerObject = Get-CimInstance -ClassName Win32_ComputerSystem
         if ($null -eq $computerObject -or $null -eq $computerObject.Domain)
         {
             Write-Verbose -Message "Can't find machine's domain name"

--- a/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.psm1
+++ b/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.psm1
@@ -1,21 +1,34 @@
-#
-# xWaitForCluster: DSC Resource that will wait for given name of Cluster, it checks the state of the cluster for given # interval until the cluster is found or the number of retries is reached.
-#
-#
+<#
+    .SYNOPSIS
+        Get the values for which failover cluster and for how long to wait for the
+        cluster to exist.
 
+    .PARAMETER Name
+        Name of the cluster to wait for.
 
-#
-# The Get-TargetResource cmdlet.
-#
+    .PARAMETER RetryIntervalSec
+        Interval to check for cluster existence. Default values is 10 seconds.
+
+    .PARAMETER RetryCount
+        Maximum number of retries to check for cluster existence. Default value
+        is 50 retries.
+#>
 function Get-TargetResource
 {
-    [OutputType([Hashtable])]
+    [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
 
-        [UInt64] $RetryIntervalSec = 10,
-        [UInt32] $RetryCount = 50
+        [Parameter()]
+        [System.UInt64]
+        $RetryIntervalSec = 10,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 50
     )
 
     @{
@@ -25,102 +38,138 @@ function Get-TargetResource
     }
 }
 
-#
-# The Set-TargetResource cmdlet.
-#
+<#
+    .SYNOPSIS
+        Waits for the specific failover cluster to exist. It will throw an error if the
+        cluster has not been detected during the timeout period.
+
+    .PARAMETER Name
+        Name of the cluster to wait for.
+
+    .PARAMETER RetryIntervalSec
+        Interval to check for cluster existence. Default values is 10 seconds.
+
+    .PARAMETER RetryCount
+        Maximum number of retries to check for cluster existence. Default value
+        is 50 retries.
+#>
 function Set-TargetResource
 {
     param
     (
-        [parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
 
-        [UInt64] $RetryIntervalSec = 10,
-        [UInt32] $RetryCount = 50
+        [Parameter()]
+        [System.UInt64]
+        $RetryIntervalSec = 10,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 50
     )
 
     $clusterFound = $false
-    Write-Verbose -Message "Checking for cluster $Name ..."
+    Write-Verbose -Message "Checking for the existance of failover cluster $Name."
 
     for ($count = 0; $count -lt $RetryCount; $count++)
     {
         try
         {
-            $ComputerInfo = Get-WmiObject Win32_ComputerSystem
-            if (($ComputerInfo -eq $null) -or ($ComputerInfo.Domain -eq $null))
+            $computerObject = Get-CimInstance -Class Win32_ComputerSystem
+            if ($null -eq $computerObject -or $null -eq $computerObject.Domain)
             {
                 Write-Verbose -Message "Can't find machine's domain name"
-                break;
+                break
             }
 
-            $cluster = Get-Cluster -Name $Name -Domain $ComputerInfo.Domain
+            $cluster = Get-Cluster -Name $Name -Domain $computerObject.Domain
 
-            if ($cluster -ne $null)
+            if ($null -ne $cluster)
             {
-                Write-Verbose -Message "Found cluster $Name"
+                Write-Verbose -Message "Found failover cluster $Name"
                 $clusterFound = $true
-
-                break;
+                break
             }
-
         }
         catch
         {
-             Write-Verbose -Message "Cluster $Name not found. Will retry again after $RetryIntervalSec sec"
+             Write-Verbose -Message "Failover cluster $Name not found. Will retry again after $RetryIntervalSec sec"
         }
 
-        Write-Verbose -Message "Cluster $Name not found. Will retry again after $RetryIntervalSec sec"
+        Write-Verbose -Message "Failover cluster $Name not found. Will retry again after $RetryIntervalSec sec"
         Start-Sleep -Seconds $RetryIntervalSec
     }
 
     if (! $clusterFound)
     {
-        throw "Cluster $Name not found after $count attempts with $RetryIntervalSec sec interval"
+        throw "Failover cluster $Name not found after $count attempts with $RetryIntervalSec sec interval"
     }
 }
 
-#
-# The Test-TargetResource cmdlet.
-#
+<#
+    .SYNOPSIS
+        Test if the specific failover cluster exist.
+
+    .PARAMETER Name
+        Name of the cluster to wait for.
+
+    .PARAMETER RetryIntervalSec
+        Interval to check for cluster existence. Default values is 10 seconds.
+
+    .PARAMETER RetryCount
+        Maximum number of retries to check for cluster existence. Default value
+        is 50 retries.
+#>
 function Test-TargetResource
 {
     [OutputType([Boolean])]
     param
     (
-        [parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
 
-        [UInt64] $RetryIntervalSec = 10,
-        [UInt32] $RetryCount = 50
+        [Parameter()]
+        [System.UInt64]
+        $RetryIntervalSec = 10,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 50
     )
 
     Write-Verbose -Message "Checking for Cluster $Name ..."
 
+    $testTargetResourceReturnValue = $false
+
     try
     {
-        $ComputerInfo = Get-WmiObject Win32_ComputerSystem
-        if (($ComputerInfo -eq $null) -or ($ComputerInfo.Domain -eq $null))
+        $computerObject = Get-CimInstance -Class Win32_ComputerSystem
+        if ($null -eq $computerObject -or $null -eq $computerObject.Domain)
         {
             Write-Verbose -Message "Can't find machine's domain name"
-            $false
         }
         else
         {
-            $cluster = Get-Cluster -Name $Name -Domain $ComputerInfo.Domain
-            if ($cluster -eq $null)
+            $cluster = Get-Cluster -Name $Name -Domain $computerObject.Domain
+            if ($null -eq $cluster)
             {
-                Write-Verbose -Message "Cluster $Name not found in domain $ComputerInfo.Domain"
-                $false
+                Write-Verbose -Message "Cluster $Name not found in domain $computerObject.Domain"
             }
             else
             {
                 Write-Verbose -Message "Found cluster $Name"
-                $true
+                $testTargetResourceReturnValue = $true
             }
         }
     }
     catch
     {
         Write-Verbose -Message "Cluster $Name not found"
-        $false
     }
+
+    $testTargetResourceReturnValue
 }
 

--- a/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.schema.mof
+++ b/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.schema.mof
@@ -1,16 +1,11 @@
 #pragma namespace("\\\\.\\root\\microsoft\\windows\\DesiredStateConfiguration")
 
-[ClassVersion("1.0.0"), FriendlyName("xWaitForCluster")] 
+[ClassVersion("1.0.0"), FriendlyName("xWaitForCluster")]
 class MSFT_xWaitForCluster : OMI_BaseResource
 {
-    [key, Description("Name of the cluster")] 
-    string Name;
-       
-    [Write, Description("Interval to check the cluster existency")] 
-    Uint64 RetryIntervalSec;
-    
-    [Write, Description("Maximum number of retries to check cluster existency")] 
-    Uint32 RetryCount;      
+    [Key, Description("Name of the cluster to wait for.")] string Name;
+    [Write, Description("Interval to check for cluster existence. Default values is 10 seconds.")]  Uint64 RetryIntervalSec;
+    [Write, Description("Maximum number of retries to check for cluster existence. Default value is 50 retries.")] Uint32 RetryCount;
 };
 
 

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -110,7 +110,7 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-                    { Get-TargetResource @mockDefaultParameters } | Should -Throw "Can't find machine's domain name"
+                    { Get-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
                 }
             }
 
@@ -122,7 +122,7 @@ try
                     Mock -CommandName Get-Cluster -Verifiable
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-                    { Get-TargetResource @mockDefaultParameters } | Should -Throw ("Can't find the cluster {0}" -f $mockClusterName)
+                    { Get-TargetResource @mockDefaultParameters } | Should Throw ("Can't find the cluster {0}" -f $mockClusterName)
                 }
             }
 
@@ -160,7 +160,7 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-                    { Set-TargetResource @mockDefaultParameters } | Should -Throw "Can't find machine's domain name"
+                    { Set-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
                 }
             }
 
@@ -184,7 +184,7 @@ try
                             # This is used to evaluate that cluster do exists after New-Cluster cmdlet has been run.
                             Mock -CommandName Get-Cluster -MockWith $mockGetCluster
 
-                            { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                            { Set-TargetResource @mockDefaultParameters } | Should Not Throw
 
                             Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -202,7 +202,7 @@ try
                             # This is used to evaluate that cluster do exists after New-Cluster cmdlet has been run.
                             Mock -CommandName Get-Cluster -MockWith $mockGetCluster
 
-                            { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                            { Set-TargetResource @mockDefaultParameters } | Should Not Throw
 
                             Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -215,7 +215,7 @@ try
                     It 'Should throw the correct error message' {
                         Mock -CommandName Get-Cluster
 
-                        { Set-TargetResource @mockDefaultParameters } | Should -Throw 'Cluster creation failed. Please verify output of ''Get-Cluster'' command'
+                        { Set-TargetResource @mockDefaultParameters } | Should Throw 'Cluster creation failed. Please verify output of ''Get-Cluster'' command'
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -228,7 +228,7 @@ try
                         Mock -CommandName Get-ClusterNode
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
 
-                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -246,7 +246,7 @@ try
                     It 'Should call both Remove-ClusterNode and Add-ClusterNode cmdlet' {
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
 
-                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 1 -Scope It
@@ -283,7 +283,7 @@ try
                     It 'Should not call any of the cluster cmdlets' -Skip {
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
 
-                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -303,7 +303,7 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-                    { Test-TargetResource @mockDefaultParameters } | Should -Throw "Can't find machine's domain name"
+                    { Test-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
                 }
             }
 
@@ -320,7 +320,7 @@ try
                         Mock -CommandName Get-Cluster -Verifiable
 
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                        $testTargetResourceResult | Should -Be $false
+                        $testTargetResourceResult | Should Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -333,7 +333,7 @@ try
                         } -Verifiable
 
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                        $testTargetResourceResult | Should -Be $false
+                        $testTargetResourceResult | Should Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -346,7 +346,7 @@ try
 
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
 
-                        $testTargetResourceResult | Should -Be $false
+                        $testTargetResourceResult | Should Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -363,7 +363,7 @@ try
                     It 'Should return $false' {
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
 
-                        $testTargetResourceResult | Should -Be $false
+                        $testTargetResourceResult | Should Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -385,7 +385,7 @@ try
                 Context 'When the node already exist' {
                     It 'Should return $true' {
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                        $testTargetResourceResult | Should -Be $true
+                        $testTargetResourceResult | Should Be $true
                     }
 
                     Assert-VerifiableMocks

--- a/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
@@ -41,14 +41,14 @@ try
         $mockRetryIntervalSec = '1'
         $mockRetryCount = '1'
 
-        $mockGetWmiObject = {
+        $mockGetCimInstance = {
             return [PSCustomObject] @{
                 Domain = $mockDynamicDomainName
             }
         }
 
         $mockGetWmiObject_ParameterFilter = {
-            $Class -eq 'Win32_ComputerSystem'
+            $ClassName -eq 'Win32_ComputerSystem'
         }
 
         $mockGetCluster = {
@@ -91,15 +91,15 @@ try
                 $mockDynamicDomainName = $null
 
                 It 'Should throw the correct error message' {
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
 
-                    { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, ($mockRetryCount-1), $mockRetryIntervalSec)
+                    { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Failover cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, ($mockRetryCount-1), $mockRetryIntervalSec)
                 }
             }
 
             Context 'When the system is not in the desired state' {
                 BeforeEach {
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
                 }
 
                 Context 'When the cluster does not exist' {
@@ -114,7 +114,7 @@ try
                         $mockDynamicDomainName = $mockDomainName
 
                         It 'Should throw the correct error message' {
-                            { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, $mockRetryCount, $mockRetryIntervalSec)
+                            { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Failover cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, $mockRetryCount, $mockRetryIntervalSec)
                         }
 
                         Assert-VerifiableMocks
@@ -125,7 +125,7 @@ try
             Context 'When the system is in the desired state' {
                 Context 'When the cluster exist' {
                     BeforeEach {
-                        Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
                     }
 
@@ -142,7 +142,7 @@ try
 
         Describe 'xCluster\Test-TargetResource' -Tag Test {
             BeforeEach {
-                Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
             }
 
             Context 'When computers domain name cannot be evaluated' {

--- a/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
@@ -93,7 +93,7 @@ try
                 It 'Should throw the correct error message' {
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockCimInstance_ParameterFilter -Verifiable
 
-                    { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Failover cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, ($mockRetryCount-1), $mockRetryIntervalSec)
+                    { Set-TargetResource @mockDefaultParameters } | Should Throw ('Failover cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, ($mockRetryCount-1), $mockRetryIntervalSec)
                 }
             }
 
@@ -105,7 +105,7 @@ try
                 Context 'When the cluster does not exist' {
                     Context 'When Get-Cluster throws an error' {
                         BeforeEach {
-                            # This is used for the evaluation of that cluster do not exist.
+                            # This is used for the evaluation of a cluster that does not exist
                             Mock -CommandName Get-Cluster -MockWith {
                                 throw 'Mock Get-Cluster throw error'
                             } -ParameterFilter $mockGetCluster_ParameterFilter
@@ -114,7 +114,7 @@ try
                         $mockDynamicDomainName = $mockDomainName
 
                         It 'Should throw the correct error message' {
-                            { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Failover cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, $mockRetryCount, $mockRetryIntervalSec)
+                            { Set-TargetResource @mockDefaultParameters } | Should Throw ('Failover cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, $mockRetryCount, $mockRetryIntervalSec)
                         }
 
                         Assert-VerifiableMocks
@@ -132,7 +132,7 @@ try
                     $mockDynamicDomainName = $mockDomainName
 
                     It 'Should not throw any error' {
-                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
                     }
 
                     Assert-VerifiableMocks
@@ -158,7 +158,7 @@ try
                 Context 'When the cluster does not exist' {
                     Context 'When Get-Cluster throws an error' {
                         BeforeEach {
-                            # This is used for the evaluation of that cluster do not exist.
+                            # This is used for the evaluation of a cluster that does not exist.
                             Mock -CommandName Get-Cluster -MockWith {
                                 throw 'Mock Get-Cluster throw error'
                             } -ParameterFilter $mockGetCluster_ParameterFilter
@@ -176,7 +176,7 @@ try
 
                     Context 'When Get-Cluster returns nothing' {
                         BeforeEach {
-                            # This is used for the evaluation of that cluster do not exist.
+                            # This is used for the evaluation of a cluster that does not exist.
                             Mock -CommandName Get-Cluster -MockWith {
                                 $null
                             } -ParameterFilter $mockGetCluster_ParameterFilter
@@ -190,7 +190,8 @@ try
                         }
 
                         Assert-VerifiableMocks
-                    }                }
+                    }
+                }
             }
 
             Context 'When the system is in the desired state' {

--- a/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
@@ -47,7 +47,7 @@ try
             }
         }
 
-        $mockGetWmiObject_ParameterFilter = {
+        $mockCimInstance_ParameterFilter = {
             $ClassName -eq 'Win32_ComputerSystem'
         }
 
@@ -91,7 +91,7 @@ try
                 $mockDynamicDomainName = $null
 
                 It 'Should throw the correct error message' {
-                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockCimInstance_ParameterFilter -Verifiable
 
                     { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Failover cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, ($mockRetryCount-1), $mockRetryIntervalSec)
                 }
@@ -99,7 +99,7 @@ try
 
             Context 'When the system is not in the desired state' {
                 BeforeEach {
-                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockCimInstance_ParameterFilter -Verifiable
                 }
 
                 Context 'When the cluster does not exist' {
@@ -125,7 +125,7 @@ try
             Context 'When the system is in the desired state' {
                 Context 'When the cluster exist' {
                     BeforeEach {
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockCimInstance_ParameterFilter -Verifiable
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
                     }
 
@@ -142,7 +142,7 @@ try
 
         Describe 'xCluster\Test-TargetResource' -Tag Test {
             BeforeEach {
-                Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockCimInstance_ParameterFilter -Verifiable
             }
 
             Context 'When computers domain name cannot be evaluated' {

--- a/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
@@ -1,0 +1,218 @@
+﻿$script:DSCModuleName = 'xFailOverCluster'
+$script:DSCResourceName = 'MSFT_xWaitForCluster'
+
+#region HEADER
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup
+{
+    Import-Module -Name (Join-Path -Path (Join-Path -Path (Join-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests') -ChildPath 'Unit') -ChildPath 'Stubs') -ChildPath 'FailoverClusters.stubs.psm1') -Global -Force
+}
+
+function Invoke-TestCleanup
+{
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
+
+# Begin Testing
+try
+{
+    Invoke-TestSetup
+
+    InModuleScope $script:DSCResourceName {
+        $mockDomainName = 'domain.local'
+        $mockClusterName = 'CLUSTER001'
+        $mockRetryIntervalSec = '1'
+        $mockRetryCount = '1'
+
+        $mockGetWmiObject = {
+            return [PSCustomObject] @{
+                Domain = $mockDynamicDomainName
+            }
+        }
+
+        $mockGetWmiObject_ParameterFilter = {
+            $Class -eq 'Win32_ComputerSystem'
+        }
+
+        $mockGetCluster = {
+            return [PSCustomObject] @{
+                Domain = $mockDomainName
+                Name   = $mockClusterName
+            }
+        }
+
+        $mockGetCluster_ParameterFilter = {
+            $Name -eq $mockClusterName -and $Domain -eq $mockDomainName
+        }
+
+        $mockDefaultParameters = @{
+            Name             = $mockClusterName
+            RetryIntervalSec = $mockRetryIntervalSec
+            RetryCount       = $mockRetryCount
+        }
+
+        Describe 'xCluster\Get-TargetResource' -Tag Get {
+            Context 'When the system is either in the desired state or not in the desired state' {
+                It 'Returns a [System.Collection.Hashtable] type' {
+                    $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
+                    $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                }
+
+                It 'Returns the same values passed as parameters' {
+                    $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
+                    $getTargetResourceResult.Name              | Should Be $mockDefaultParameters.Name
+                    $getTargetResourceResult.RetryIntervalSec  | Should Be $mockDefaultParameters.RetryIntervalSec
+                    $getTargetResourceResult.RetryCount        | Should Be $mockDefaultParameters.RetryCount
+                }
+
+                Assert-VerifiableMocks
+            }
+        }
+
+        Describe 'xCluster\Set-TargetResource' -Tag Set {
+            Context 'When computers domain name cannot be evaluated' {
+                $mockDynamicDomainName = $null
+
+                It 'Should throw the correct error message' {
+                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+
+                    { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, ($mockRetryCount-1), $mockRetryIntervalSec)
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                BeforeEach {
+                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                }
+
+                Context 'When the cluster does not exist' {
+                    Context 'When Get-Cluster throws an error' {
+                        BeforeEach {
+                            # This is used for the evaluation of that cluster do not exist.
+                            Mock -CommandName Get-Cluster -MockWith {
+                                throw 'Mock Get-Cluster throw error'
+                            } -ParameterFilter $mockGetCluster_ParameterFilter
+                        }
+
+                        $mockDynamicDomainName = $mockDomainName
+
+                        It 'Should throw the correct error message' {
+                            { Set-TargetResource @mockDefaultParameters } | Should -Throw ('Cluster {0} not found after {1} attempts with {2} sec interval' -f $mockClusterName, $mockRetryCount, $mockRetryIntervalSec)
+                        }
+
+                        Assert-VerifiableMocks
+                    }
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                Context 'When the cluster exist' {
+                    BeforeEach {
+                        Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                        Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
+                    }
+
+                    $mockDynamicDomainName = $mockDomainName
+
+                    It 'Should not throw any error' {
+                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                    }
+
+                    Assert-VerifiableMocks
+                }
+            }
+        }
+
+        Describe 'xCluster\Test-TargetResource' -Tag Test {
+            BeforeEach {
+                Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+            }
+
+            Context 'When computers domain name cannot be evaluated' {
+                $mockDynamicDomainName = $null
+
+                It 'Should return the value $false' {
+                    $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
+                    $testTargetResourceResult | Should Be $false
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                Context 'When the cluster does not exist' {
+                    Context 'When Get-Cluster throws an error' {
+                        BeforeEach {
+                            # This is used for the evaluation of that cluster do not exist.
+                            Mock -CommandName Get-Cluster -MockWith {
+                                throw 'Mock Get-Cluster throw error'
+                            } -ParameterFilter $mockGetCluster_ParameterFilter
+                        }
+
+                        $mockDynamicDomainName = $mockDomainName
+
+                        It 'Should return the value $false' {
+                            $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
+                            $testTargetResourceResult | Should Be $false
+                        }
+
+                        Assert-VerifiableMocks
+                    }
+
+                    Context 'When Get-Cluster returns nothing' {
+                        BeforeEach {
+                            # This is used for the evaluation of that cluster do not exist.
+                            Mock -CommandName Get-Cluster -MockWith {
+                                $null
+                            } -ParameterFilter $mockGetCluster_ParameterFilter
+                        }
+
+                        $mockDynamicDomainName = $mockDomainName
+
+                        It 'Should return the value $false' {
+                            $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
+                            $testTargetResourceResult | Should Be $false
+                        }
+
+                        Assert-VerifiableMocks
+                    }                }
+            }
+
+            Context 'When the system is in the desired state' {
+                Context 'When the cluster exist' {
+                    BeforeEach {
+                        Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
+                    }
+
+                    $mockDynamicDomainName = $mockDomainName
+
+                    It 'Should return the value $true' {
+                        $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
+                        $testTargetResourceResult | Should Be $true
+                    }
+
+                    Assert-VerifiableMocks
+                }
+            }
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xWaitForCluster
  - Refactored the unit test for this resource to use stubs and increase coverage
    (issue #78).
  - Now the Test-TargetResource correctly returns false if the domain namn cannot
    be evaluated  (issue #107).
  - Changed the code to be more aligned with the style guideline.
  - Updated parameter description in the schema.mof.
  - Resolved Script Analyzer warnings (issue #54).

**This Pull Request (PR) fixes the following issues:**
Fixes #78 
Fixes #107 
Fixes #54 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/108)
<!-- Reviewable:end -->
