### PR TITLE
xCluster: Fixed PSSA rule warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@
     ([issue #72](https://github.com/PowerShell/xFailOverCluster/issues/72)).
   - Set-TargetResource now correctly throws and error if domain name cannot be
     evaluated ([issue #71](https://github.com/PowerShell/xFailOverCluster/issues/71)).
+  - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
+    Get-CimInstance (issue #49).
 - Changes to xWaitForCluster
   - Added example
     - 1-WaitForFailoverClusterToBePresent.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - Fixed typos in parameter descriptions in README.md.
 - Changes to xCluster
   - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
-    Get-CimInstance (issue #49).
+    Get-CimInstance ([issue #49](https://github.com/PowerShell/xFailOverCluster/issues/49)).
 
 ## 1.7.0.0
 
@@ -86,13 +86,7 @@
   - Test-TargetResource now throws and error if domain name cannot be evaluated
     ([issue #72](https://github.com/PowerShell/xFailOverCluster/issues/72)).
   - Set-TargetResource now correctly throws and error if domain name cannot be
-<<<<<<< HEAD
     evaluated ([issue #71](https://github.com/PowerShell/xFailOverCluster/issues/71)).
-  - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
-    Get-CimInstance (issue #49).
-=======
-    evaluated (issue #71).
->>>>>>> Updated CHANGELOG.md
 - Changes to xWaitForCluster
   - Added example
     - 1-WaitForFailoverClusterToBePresent.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
     generic description of the possible settings for the Role parameter. The
     previous URL was still correct but focused on Hyper-V in particular.
   - Fixed typos in parameter descriptions in README.md.
+- Changes to xCluster
+  - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
+    Get-CimInstance (issue #49).
 
 ## 1.7.0.0
 
@@ -83,9 +86,13 @@
   - Test-TargetResource now throws and error if domain name cannot be evaluated
     ([issue #72](https://github.com/PowerShell/xFailOverCluster/issues/72)).
   - Set-TargetResource now correctly throws and error if domain name cannot be
+<<<<<<< HEAD
     evaluated ([issue #71](https://github.com/PowerShell/xFailOverCluster/issues/71)).
   - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
     Get-CimInstance (issue #49).
+=======
+    evaluated (issue #71).
+>>>>>>> Updated CHANGELOG.md
 - Changes to xWaitForCluster
   - Added example
     - 1-WaitForFailoverClusterToBePresent.ps1

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -29,7 +29,7 @@ function Get-TargetResource
         $DomainAdministratorCredential
     )
 
-    $computerInformation = Get-WmiObject -Class Win32_ComputerSystem
+    $computerInformation = Get-CimInstance -ClassName Win32_ComputerSystem
     if (($null -eq $computerInformation) -or ($null -eq $computerInformation.Domain))
     {
         throw 'Can''t find machine''s domain name'
@@ -107,7 +107,7 @@ function Set-TargetResource
 
     Write-Verbose -Message "Checking if Cluster $Name is present ..."
 
-    $computerInformation = Get-WmiObject -Class Win32_ComputerSystem
+    $computerInformation = Get-CimInstance -ClassName Win32_ComputerSystem
     if (($null -eq $computerInformation) -or ($null -eq $computerInformation.Domain))
     {
         throw 'Can''t find machine''s domain name'
@@ -228,7 +228,7 @@ function Test-TargetResource
 
     Write-Verbose -Message "Checking if Cluster $Name is present ..."
 
-    $ComputerInfo = Get-WmiObject -Class Win32_ComputerSystem
+    $ComputerInfo = Get-CimInstance -ClassName Win32_ComputerSystem
     if (($null -eq $ComputerInfo) -or ($null -eq $ComputerInfo.Domain))
     {
         throw "Can't find machine's domain name"

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -45,15 +45,15 @@ try
         $mockClusterName = 'CLUSTER001'
         $mockStaticIpAddress = '192.168.10.10'
 
-        $mockGetWmiObject = {
+        $mockGetCimInstance = {
             return [PSCustomObject] @{
                 Domain = $mockDynamicDomainName
                 Name   = $mockDynamicServerName
             }
         }
 
-        $mockGetWmiObject_ParameterFilter = {
-            $Class -eq 'Win32_ComputerSystem'
+        $mockGetCimInstance_ParameterFilter = {
+            $ClassName -eq 'Win32_ComputerSystem'
         }
 
         $mockGetCluster = {
@@ -108,7 +108,7 @@ try
                     $mockDynamicDomainName = $null
                     $mockDynamicServerName = $mockServerName
 
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     { Get-TargetResource @mockDefaultParameters } | Should -Throw "Can't find machine's domain name"
                 }
@@ -120,7 +120,7 @@ try
                     $mockDynamicServerName = $mockServerName
 
                     Mock -CommandName Get-Cluster -Verifiable
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     { Get-TargetResource @mockDefaultParameters } | Should -Throw ("Can't find the cluster {0}" -f $mockClusterName)
                 }
@@ -128,7 +128,7 @@ try
 
             Context 'When the system is not in the desired state' {
                 BeforeEach {
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
                     Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
                     Mock -CommandName Get-ClusterGroup -MockWith $mockGetClusterGroup -ParameterFilter $mockGetClusterGroup_ParameterFilter -Verifiable
                     Mock -CommandName Get-ClusterParameter -MockWith $mockGetClusterParameter -Verifiable
@@ -158,7 +158,7 @@ try
                     $mockDynamicDomainName = $null
                     $mockDynamicServerName = $mockServerName
 
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     { Set-TargetResource @mockDefaultParameters } | Should -Throw "Can't find machine's domain name"
                 }
@@ -169,7 +169,7 @@ try
                     Mock -CommandName New-Cluster -Verifiable
                     Mock -CommandName Remove-ClusterNode -Verifiable
                     Mock -CommandName Add-ClusterNode -Verifiable
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
                 }
 
                 $mockDynamicDomainName = $mockDomainName
@@ -261,7 +261,7 @@ try
                     Mock -CommandName New-Cluster -Verifiable
                     Mock -CommandName Remove-ClusterNode -Verifiable
                     Mock -CommandName Add-ClusterNode -Verifiable
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
                     Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
                     Mock -CommandName Get-ClusterParameter -MockWith $mockGetClusterParameter -Verifiable
 
@@ -301,7 +301,7 @@ try
                     $mockDynamicDomainName = $null
                     $mockDynamicServerName = $mockServerName
 
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     { Test-TargetResource @mockDefaultParameters } | Should -Throw "Can't find machine's domain name"
                 }
@@ -309,7 +309,7 @@ try
 
             Context 'When the system is not in the desired state' {
                 BeforeEach {
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
                 }
 
                 $mockDynamicDomainName = $mockDomainName
@@ -374,7 +374,7 @@ try
             Context 'When the system is in the desired state' {
                 BeforeEach {
                     Mock -CommandName Get-ClusterNode -MockWith $mockGetClusterNode -Verifiable
-                    Mock -CommandName Get-WmiObject -MockWith $mockGetWmiObject -ParameterFilter $mockGetWmiObject_ParameterFilter -Verifiable
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
                     Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
                 }
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xCluster
  - Resolved Script Analyzer rule warnings by changing Get-WmiObject to Get-CimInstance (issue #49).

**This Pull Request (PR) fixes the following issues:**
Fixes #49 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/110)
<!-- Reviewable:end -->
