### PR TITLE
xFailOverCluster: Localization support, localized strings in xClusterDisk and some cleanup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@
   - Added a script file (Tests\Unit\Stubs\Write-ModuleStubFile.ps1) to be able
     to rebuild the stub file (FailoverClusters.stubs.psm1) whenever needed.
   - Added code block around types in README.md.
+  - Added a common resource helper module with helper functions for localization.
+    - Added helper functions; Get-LocalizedData, New-InvalidResultException,
+      New-ObjectNotFoundException, InvalidOperationException and InvalidArgumentException.
+  - Fixed lint error MD034 and fixed typos in README.md.
 - Changes to xCluster
   - Added examples
     - 1-CreateFirstNodeOfAFailoverCluster.ps1
@@ -74,6 +78,7 @@
     - 1-WaitForFailoverClusterToBePresent.ps1
   - Added link to example from README.md
 - Changes to xClusterDisk
+  - Fixed test that was failing in AppVeyor (issue #55).
   - Refactored the unit test for this resource to use stubs and increase coverage
     (issue #74).
   - Removed an evaluation that called Test-TargetResource in Set-TargetResource
@@ -84,7 +89,10 @@
     - 1-AddClusterDisk.ps1
     - 2-RemoveClusterDisk.ps1
   - Added links to examples from README.md.
+  - Enabled localization for all strings (issue #84).
 - Changes to xClusterPreferredOwner
+  - Script Analyzer warnings have been fixed (issue #50). This also failed the
+    tests for the resource.
   - Refactored the unit test for this resource to use stubs and increase coverage
     (issue #76).
   - Changed the code to be more aligned with the style guideline.
@@ -100,6 +108,7 @@
   - Added example (issue #57)
     - 1-ChangeClusterNetwork.ps1
   - Added links to examples from README.md.
+  - Replace an URL which describes more generic the Role setting for xClusterNetwork.
 
 ### 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Changes to xFailOverCluster
+  - Added a common resource helper module with helper functions for localization.
+    - Added helper functions; Get-LocalizedData, New-InvalidResultException,
+      New-ObjectNotFoundException, InvalidOperationException and InvalidArgumentException.
+  - Fixed lint error MD034 and fixed typos in README.md.
+- Changes to xClusterDisk
+  - Enabled localization for all strings (issue #84).
+- Changes to xClusterNetwork
+  - Replaced an URL which describes more generic the Role setting for xClusterNetwork.
+  - Fixed typos in parameter descriptions in README.md.
+
 ## 1.7.0.0
 
 - Changes to xClusterPreferredOwner
@@ -55,10 +66,6 @@
   - Added a script file (Tests\Unit\Stubs\Write-ModuleStubFile.ps1) to be able
     to rebuild the stub file (FailoverClusters.stubs.psm1) whenever needed.
   - Added code block around types in README.md.
-  - Added a common resource helper module with helper functions for localization.
-    - Added helper functions; Get-LocalizedData, New-InvalidResultException,
-      New-ObjectNotFoundException, InvalidOperationException and InvalidArgumentException.
-  - Fixed lint error MD034 and fixed typos in README.md.
 - Changes to xCluster
   - Added examples
     - 1-CreateFirstNodeOfAFailoverCluster.ps1
@@ -78,7 +85,6 @@
     - 1-WaitForFailoverClusterToBePresent.ps1
   - Added link to example from README.md
 - Changes to xClusterDisk
-  - Fixed test that was failing in AppVeyor (issue #55).
   - Refactored the unit test for this resource to use stubs and increase coverage
     (issue #74).
   - Removed an evaluation that called Test-TargetResource in Set-TargetResource
@@ -89,10 +95,7 @@
     - 1-AddClusterDisk.ps1
     - 2-RemoveClusterDisk.ps1
   - Added links to examples from README.md.
-  - Enabled localization for all strings (issue #84).
 - Changes to xClusterPreferredOwner
-  - Script Analyzer warnings have been fixed (issue #50). This also failed the
-    tests for the resource.
   - Refactored the unit test for this resource to use stubs and increase coverage
     (issue #76).
   - Changed the code to be more aligned with the style guideline.
@@ -108,7 +111,6 @@
   - Added example (issue #57)
     - 1-ChangeClusterNetwork.ps1
   - Added links to examples from README.md.
-  - Replace an URL which describes more generic the Role setting for xClusterNetwork.
 
 ### 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 - Changes to xClusterDisk
   - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
 - Changes to xClusterNetwork
-  - Replaced an URL which describes more generic the Role setting for xClusterNetwork.
+  - Replaced the URL for the parameter Role in README.md. The new URL is a more
+    generic description of the possible settings for the Role parameter. The
+    previous URL was still correct but focused on Hyper-V in particular.
   - Fixed typos in parameter descriptions in README.md.
 
 ## 1.7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
       New-InvalidArgumentException.
   - Fixed lint error MD034 and fixed typos in README.md.
 - Changes to xClusterDisk
-  - Enabled localization for all strings ([issue #84](/issues/84)).
+  - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
 - Changes to xClusterNetwork
   - Replaced an URL which describes more generic the Role setting for xClusterNetwork.
   - Fixed typos in parameter descriptions in README.md.
@@ -17,46 +17,46 @@
 ## 1.7.0.0
 
 - Changes to xClusterPreferredOwner
-  - Script Analyzer warnings have been fixed ([issue #50](/issues/50)). This also failed the
+  - Script Analyzer warnings have been fixed ([issue #50](https://github.com/PowerShell/xFailOverCluster/issues/50)). This also failed the
     tests for the resource.
 - Changes to xClusterDisk
-  - Fixed test that was failing in  AppVeyor ([issue #55](/issues/55)).
+  - Fixed test that was failing in  AppVeyor ([issue #55](https://github.com/PowerShell/xFailOverCluster/issues/55)).
 - Changes to xFailOverCluster
-  - Added 'Code of Conduct' text to the README.md ([issue #44](/issues/44)).
-  - Added TOC for all resources in the README.md ([issue #43](/issues/43)).
+  - Added 'Code of Conduct' text to the README.md ([issue #44](https://github.com/PowerShell/xFailOverCluster/issues/44)).
+  - Added TOC for all resources in the README.md ([issue #43](https://github.com/PowerShell/xFailOverCluster/issues/43)).
   - Fixed typos and lint errors in README.md.
   - Fixed style issue in example in README.md.
   - Removed 'Unreleased' "tag" from the resources xClusterQuorum and
-    xClusterDisk ([issue #36](/issues/36))
+    xClusterDisk ([issue #36](https://github.com/PowerShell/xFailOverCluster/issues/36))
   - Added new sections to each resource (Requirements, Parameters and Examples)
     in the README.md. Some does not yet have any examples, so they are set to
     'None.'.
   - Added GitHub templates PULL\_REQUEST\_TEMPLATE, ISSUE_TEMPLATE and
-    CONTRIBUTING.md ([issue #45](/issues/45)).
+    CONTRIBUTING.md ([issue #45](https://github.com/PowerShell/xFailOverCluster/issues/45)).
   - Split the change log from README.md to a separate file CHANGELOG.md
-    [issue #48](/issues/48).
-  - Added the resource xClusterPreferredOwner to README.md ([issue #51](/issues/51)).
-  - Added the resource xClusterNetwork to README.md ([issue #56](/issues/56)).
+    [issue #48](https://github.com/PowerShell/xFailOverCluster/issues/48).
+  - Added the resource xClusterPreferredOwner to README.md ([issue #51](https://github.com/PowerShell/xFailOverCluster/issues/51)).
+  - Added the resource xClusterNetwork to README.md ([issue #56](https://github.com/PowerShell/xFailOverCluster/issues/56)).
   - Removed Credential parameter from parameter list for xWaitForCluster.
     Parameter Credential does not exist in the schema.mof of the resource
-    ([issue #62](/issues/62)).
+    ([issue #62](https://github.com/PowerShell/xFailOverCluster/issues/62)).
   - Now all parameters in the README.md list their data type and type qualifier
-    ([issue #58](/issues/58)).
+    ([issue #58](https://github.com/PowerShell/xFailOverCluster/issues/58)).
   - Added Import-DscResource to example in README.md.
-  - Added CodeCov and opt-in for all common tests ([issue #41](/issues/41)).
+  - Added CodeCov and opt-in for all common tests ([issue #41](https://github.com/PowerShell/xFailOverCluster/issues/41)).
   - Added CodeCov badge to README.md
     - Fixed CodeCov badge links so they now can be clicked on.
   - Fixed lint rule MD013 in CHANGELOG.md.
   - Fixed lint rule MD013 in README.md.
   - Fixed lint rule MD024 in README.md.
   - Fixed lint rule MD032 in README.md.
-  - Removed example from README.md ([issue #42](/issues/42)).
+  - Removed example from README.md ([issue #42](https://github.com/PowerShell/xFailOverCluster/issues/42)).
   - Fixed typo in filename for ISSUE\_TEMPLATE. Was 'ISSUE\_TEMPLATE', now it is
     correctly 'ISSUE\_TEMPLATE.md'.
   - Changed appveyor.yml to use the new default test framework in the AppVeyor
     module in DscResource.Tests (AppVeyor.psm1).
   - Added VS Code workspace settings file with formatting settings matching the
-    Style Guideline ([issue #67](/issues/67)). That will make it possible inside VS Code to
+    Style Guideline ([issue #67](https://github.com/PowerShell/xFailOverCluster/issues/67)). That will make it possible inside VS Code to
     press SHIFT+ALT+F, or press F1 and choose 'Format document' in the list. The
     PowerShell code will then be formatted according to the Style Guideline
     (although maybe not complete, but would help a long way).
@@ -75,41 +75,41 @@
   - Fixed typo in xCluster parameter description.
   - Added links to examples from README.md
   - Refactored the unit test for this resource to use stubs and increase coverage
-    ([issue #73](/issues/73)).
+    ([issue #73](https://github.com/PowerShell/xFailOverCluster/issues/73)).
     - Removed the password file (MSFT_xCluster.password.txt) which seemed unnecessary.
   - Test-TargetResource now throws and error if domain name cannot be evaluated
-    ([issue #72](/issues/72)).
+    ([issue #72](https://github.com/PowerShell/xFailOverCluster/issues/72)).
   - Set-TargetResource now correctly throws and error if domain name cannot be
-    evaluated ([issue #71](/issues/71)).
+    evaluated ([issue #71](https://github.com/PowerShell/xFailOverCluster/issues/71)).
 - Changes to xWaitForCluster
   - Added example
     - 1-WaitForFailoverClusterToBePresent.ps1
   - Added link to example from README.md
 - Changes to xClusterDisk
   - Refactored the unit test for this resource to use stubs and increase coverage
-    ([issue #74](/issues/74)).
+    ([issue #74](https://github.com/PowerShell/xFailOverCluster/issues/74)).
   - Removed an evaluation that called Test-TargetResource in Set-TargetResource
     method and instead added logic so that Set-TargetResource evaluates if it
-    should remove a disk ([issue #90](/issues/90)).
+    should remove a disk ([issue #90](https://github.com/PowerShell/xFailOverCluster/issues/90)).
   - Changed the code to be more aligned with the style guideline.
-  - Added examples ([issue #46](/issues/46))
+  - Added examples ([issue #46](https://github.com/PowerShell/xFailOverCluster/issues/46))
     - 1-AddClusterDisk.ps1
     - 2-RemoveClusterDisk.ps1
   - Added links to examples from README.md.
 - Changes to xClusterPreferredOwner
   - Refactored the unit test for this resource to use stubs and increase coverage
-    ([issue #76](/issues/76)).
+    ([issue #76](https://github.com/PowerShell/xFailOverCluster/issues/76)).
   - Changed the code to be more aligned with the style guideline.
-  - Added examples ([issue #52](/issues/52))
+  - Added examples ([issue #52](https://github.com/PowerShell/xFailOverCluster/issues/52))
     - 1-AddPreferredOwner.ps1
     - 2-RemovePreferredOwner.ps1
   - Added links to examples from README.md.
 - Changes to xClusterNetwork
   - Refactored the unit test for this resource to use stubs and increase coverage
-    ([issue #75](/issues/75)).
+    ([issue #75](https://github.com/PowerShell/xFailOverCluster/issues/75)).
   - Changed the code to be more aligned with the style guideline.
   - Updated resource and parameter description in README.md and schema.mof.
-  - Added example ([issue #57](/issues/57))
+  - Added example ([issue #57](https://github.com/PowerShell/xFailOverCluster/issues/57))
     - 1-ChangeClusterNetwork.ps1
   - Added links to examples from README.md.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 - Changes to xFailOverCluster
   - Added a common resource helper module with helper functions for localization.
     - Added helper functions; Get-LocalizedData, New-InvalidResultException,
-      New-ObjectNotFoundException, InvalidOperationException and InvalidArgumentException.
+      New-ObjectNotFoundException, New-InvalidOperationException and
+      New-InvalidArgumentException.
   - Fixed lint error MD034 and fixed typos in README.md.
 - Changes to xClusterDisk
-  - Enabled localization for all strings (issue #84).
+  - Enabled localization for all strings ([issue #84](/issues/84)).
 - Changes to xClusterNetwork
   - Replaced an URL which describes more generic the Role setting for xClusterNetwork.
   - Fixed typos in parameter descriptions in README.md.
@@ -16,46 +17,46 @@
 ## 1.7.0.0
 
 - Changes to xClusterPreferredOwner
-  - Script Analyzer warnings have been fixed (issue #50). This also failed the
+  - Script Analyzer warnings have been fixed ([issue #50](/issues/50)). This also failed the
     tests for the resource.
 - Changes to xClusterDisk
-  - Fixed test that was failing in  AppVeyor (issue #55).
+  - Fixed test that was failing in  AppVeyor ([issue #55](/issues/55)).
 - Changes to xFailOverCluster
-  - Added 'Code of Conduct' text to the README.md (issue #44).
-  - Added TOC for all resources in the README.md (issue #43).
+  - Added 'Code of Conduct' text to the README.md ([issue #44](/issues/44)).
+  - Added TOC for all resources in the README.md ([issue #43](/issues/43)).
   - Fixed typos and lint errors in README.md.
   - Fixed style issue in example in README.md.
   - Removed 'Unreleased' "tag" from the resources xClusterQuorum and
-    xClusterDisk (issue #36)
+    xClusterDisk ([issue #36](/issues/36))
   - Added new sections to each resource (Requirements, Parameters and Examples)
     in the README.md. Some does not yet have any examples, so they are set to
     'None.'.
   - Added GitHub templates PULL\_REQUEST\_TEMPLATE, ISSUE_TEMPLATE and
-    CONTRIBUTING.md (issue #45).
+    CONTRIBUTING.md ([issue #45](/issues/45)).
   - Split the change log from README.md to a separate file CHANGELOG.md
-    (issue #48).
-  - Added the resource xClusterPreferredOwner to README.md (issue #51).
-  - Added the resource xClusterNetwork to README.md (issue #56).
+    [issue #48](/issues/48).
+  - Added the resource xClusterPreferredOwner to README.md ([issue #51](/issues/51)).
+  - Added the resource xClusterNetwork to README.md ([issue #56](/issues/56)).
   - Removed Credential parameter from parameter list for xWaitForCluster.
     Parameter Credential does not exist in the schema.mof of the resource
-    (issue #62).
+    ([issue #62](/issues/62)).
   - Now all parameters in the README.md list their data type and type qualifier
-    (issue #58.)
+    ([issue #58](/issues/58)).
   - Added Import-DscResource to example in README.md.
-  - Added CodeCov and opt-in for all common tests (issue #41).
+  - Added CodeCov and opt-in for all common tests ([issue #41](/issues/41)).
   - Added CodeCov badge to README.md
     - Fixed CodeCov badge links so they now can be clicked on.
   - Fixed lint rule MD013 in CHANGELOG.md.
   - Fixed lint rule MD013 in README.md.
   - Fixed lint rule MD024 in README.md.
   - Fixed lint rule MD032 in README.md.
-  - Removed example from README.md (issue #42).
+  - Removed example from README.md ([issue #42](/issues/42)).
   - Fixed typo in filename for ISSUE\_TEMPLATE. Was 'ISSUE\_TEMPLATE', now it is
     correctly 'ISSUE\_TEMPLATE.md'.
   - Changed appveyor.yml to use the new default test framework in the AppVeyor
     module in DscResource.Tests (AppVeyor.psm1).
   - Added VS Code workspace settings file with formatting settings matching the
-    Style Guideline (issue #67). That will make it possible inside VS Code to
+    Style Guideline ([issue #67](/issues/67)). That will make it possible inside VS Code to
     press SHIFT+ALT+F, or press F1 and choose 'Format document' in the list. The
     PowerShell code will then be formatted according to the Style Guideline
     (although maybe not complete, but would help a long way).
@@ -74,41 +75,41 @@
   - Fixed typo in xCluster parameter description.
   - Added links to examples from README.md
   - Refactored the unit test for this resource to use stubs and increase coverage
-    (issue #73).
+    ([issue #73](/issues/73)).
     - Removed the password file (MSFT_xCluster.password.txt) which seemed unnecessary.
   - Test-TargetResource now throws and error if domain name cannot be evaluated
-    (issue #72).
+    ([issue #72](/issues/72)).
   - Set-TargetResource now correctly throws and error if domain name cannot be
-    evaluated (issue #71).
+    evaluated ([issue #71](/issues/71)).
 - Changes to xWaitForCluster
   - Added example
     - 1-WaitForFailoverClusterToBePresent.ps1
   - Added link to example from README.md
 - Changes to xClusterDisk
   - Refactored the unit test for this resource to use stubs and increase coverage
-    (issue #74).
+    ([issue #74](/issues/74)).
   - Removed an evaluation that called Test-TargetResource in Set-TargetResource
     method and instead added logic so that Set-TargetResource evaluates if it
-    should remove a disk (issue #90).
+    should remove a disk ([issue #90](/issues/90)).
   - Changed the code to be more aligned with the style guideline.
-  - Added examples (issue #46)
+  - Added examples ([issue #46](/issues/46))
     - 1-AddClusterDisk.ps1
     - 2-RemoveClusterDisk.ps1
   - Added links to examples from README.md.
 - Changes to xClusterPreferredOwner
   - Refactored the unit test for this resource to use stubs and increase coverage
-    (issue #76).
+    ([issue #76](/issues/76)).
   - Changed the code to be more aligned with the style guideline.
-  - Added examples (issue #52)
+  - Added examples ([issue #52](/issues/52))
     - 1-AddPreferredOwner.ps1
     - 2-RemovePreferredOwner.ps1
   - Added links to examples from README.md.
 - Changes to xClusterNetwork
   - Refactored the unit test for this resource to use stubs and increase coverage
-    (issue #75).
+    ([issue #75](/issues/75)).
   - Changed the code to be more aligned with the style guideline.
   - Updated resource and parameter description in README.md and schema.mof.
-  - Added example (issue #57)
+  - Added example ([issue #57](/issues/57))
     - 1-ChangeClusterNetwork.ps1
   - Added links to examples from README.md.
 

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -1,0 +1,262 @@
+﻿<#
+    .SYNOPSIS
+        Creates and throws an invalid argument exception.
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown.
+
+    .PARAMETER ArgumentName
+        The name of the invalid argument that is causing this error to be thrown.
+#>
+function New-InvalidArgumentException
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Message,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ArgumentName
+    )
+
+    $argumentException = New-Object -TypeName 'ArgumentException' `
+                                    -ArgumentList @($Message, $ArgumentName)
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @($argumentException, $ArgumentName, 'InvalidArgument', $null)
+    }
+
+    $errorRecord = New-Object @newObjectParameters
+
+    throw $errorRecord
+}
+
+<#
+    .SYNOPSIS
+        Creates and throws an invalid operation exception.
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown.
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error.
+#>
+function New-InvalidOperationException
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Message,
+
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord)
+    {
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' `
+                                                -ArgumentList @($Message)
+    }
+    else
+    {
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' `
+                                                -ArgumentList @($Message, $ErrorRecord.Exception)
+    }
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $invalidOperationException.ToString(),
+            'MachineStateIncorrect',
+            'InvalidOperation',
+            $null
+            )
+    }
+
+    $errorRecordToThrow = New-Object @newObjectParameters
+
+    throw $errorRecordToThrow
+}
+
+<#
+    .SYNOPSIS
+        Creates and throws an object not found exception.
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown.
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error.
+#>
+function New-ObjectNotFoundException
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Message,
+
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord)
+    {
+        $exception = New-Object -TypeName 'System.Exception' `
+                                -ArgumentList @($Message)
+    }
+    else
+    {
+        $exception = New-Object -TypeName 'System.Exception' `
+                                -ArgumentList @($Message, $ErrorRecord.Exception)
+    }
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $exception.ToString(),
+            'MachineStateIncorrect',
+            'ObjectNotFound',
+            $null
+            )
+    }
+
+    $errorRecordToThrow = New-Object @newObjectParameters
+
+    throw $errorRecordToThrow
+}
+
+<#
+    .SYNOPSIS
+        Creates and throws an invalid result exception.
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown.
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error.
+#>
+function New-InvalidResultException
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Message,
+
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord)
+    {
+        $exception = New-Object -TypeName 'System.Exception' `
+                                -ArgumentList @($Message)
+    }
+    else
+    {
+        $exception = New-Object -TypeName 'System.Exception' `
+                                -ArgumentList @($Message, $ErrorRecord.Exception)
+    }
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $exception.ToString(),
+            'MachineStateIncorrect',
+            'InvalidResult',
+            $null
+            )
+    }
+
+    $errorRecordToThrow = New-Object @newObjectParameters
+
+    throw $errorRecordToThrow
+}
+
+<#
+    .SYNOPSIS
+        Retrieves the localized string data based on the machine's culture.
+        Falls back to en-US strings if the machine's culture is not supported.
+
+    .PARAMETER ResourceName
+        The name of the resource as it appears before '.strings.psd1' of the localized string file.
+        For example:
+            For WindowsOptionalFeature: MSFT_WindowsOptionalFeature
+            For Service: MSFT_ServiceResource
+            For Registry: MSFT_RegistryResource
+            For Helper: xSQLServerHelper
+
+    .PARAMETER ScriptRoot
+        Optional. The root path where to expect to find the culture folder. This is only needed
+        for localization in helper modules. This should not normally be used for resources.
+#>
+function Get-LocalizedData
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ResourceName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ScriptRoot
+    )
+
+    if ( -not $ScriptRoot )
+    {
+        $resourceDirectory = Join-Path -Path $PSScriptRoot -ChildPath $ResourceName
+        $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath $PSUICulture
+    }
+    else
+    {
+        $localizedStringFileLocation = Join-Path -Path $ScriptRoot -ChildPath $PSUICulture
+    }
+
+    if (-not (Test-Path -Path $localizedStringFileLocation))
+    {
+        # Fallback to en-US
+        if ( -not $ScriptRoot )
+        {
+            $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath 'en-US'
+        }
+        else
+        {
+            $localizedStringFileLocation = Join-Path -Path $ScriptRoot -ChildPath 'en-US'
+        }
+    }
+
+    Import-LocalizedData `
+        -BindingVariable 'localizedData' `
+        -FileName "$ResourceName.strings.psd1" `
+        -BaseDirectory $localizedStringFileLocation
+
+    return $localizedData
+}
+
+Export-ModuleMember -Function @(
+    'New-InvalidArgumentException',
+    'New-InvalidOperationException',
+    'New-ObjectNotFoundException',
+    'New-InvalidResultException',
+    'Get-LocalizedData' )

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -57,6 +57,7 @@ function New-InvalidOperationException
         [System.String]
         $Message,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord
@@ -108,6 +109,7 @@ function New-ObjectNotFoundException
         [System.String]
         $Message,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord
@@ -159,6 +161,7 @@ function New-InvalidResultException
         [System.String]
         $Message,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord

--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
@@ -1,3 +1,8 @@
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath 'CommonResourceHelper.psm1')
+
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xClusterDisk'
+
 <#
     .SYNOPSIS
         Returns the current state of the failover cluster disk resource.
@@ -78,14 +83,14 @@ function Set-TargetResource
     {
         if ($getTargetResourceResult.Ensure -ne $Ensure)
         {
-            Write-Verbose "Add the disk $Number to the cluster"
+            Write-Verbose -Message ($script:localizedData.AddDiskToCluster -f $Number)
 
             Get-ClusterAvailableDisk | Where-Object -FilterScript { $_.Number -eq $Number } | Add-ClusterDisk
         }
 
         if ($getTargetResourceResult.Label -ne $Label)
         {
-            Write-Verbose "Set the disk $Number label to '$Label'"
+            Write-Verbose -Message ($script:localizedData.SetDiskLabel -f $Number, $Label)
 
             $diskInstance = Get-CimInstance -ClassName MSCluster_Disk -Namespace 'Root\MSCluster' -Filter "Number = $Number"
 
@@ -102,7 +107,7 @@ function Set-TargetResource
     {
         if ($getTargetResourceResult.Ensure -eq 'Present' -and $Ensure -eq 'Absent')
         {
-            Write-Verbose "Remove the disk $Number from the cluster"
+            Write-Verbose -Message ($script:localizedData.RemoveDiskFromCluster -f $Number)
 
             $diskInstance = Get-CimInstance -ClassName MSCluster_Disk -Namespace 'Root\MSCluster' -Filter "Number = $Number"
 

--- a/DSCResources/MSFT_xClusterDisk/en-US/MSFT_xClusterDisk.strings.psd1
+++ b/DSCResources/MSFT_xClusterDisk/en-US/MSFT_xClusterDisk.strings.psd1
@@ -1,0 +1,7 @@
+# Localized resources for xClusterDisk
+
+ConvertFrom-StringData @'
+    AddDiskToCluster = Add the disk {0} to the cluster.
+    SetDiskLabel = Set the disk label for the disk {0} to '{1}'.
+    RemoveDiskFromCluster = Remove the disk {0} from the cluster.
+'@

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Configures a cluster network in a failover cluster.
 
 #### Parameters for xClusterNetwork
 
-* **`[String]` Address** _(Key)_: The adress for the cluster network in the format
+* **`[String]` Address** _(Key)_: The address for the cluster network in the format
   '10.0.0.0'.
-* **`[String]` AddressMask** _(Key)_: The adress mask for the cluster network in
+* **`[String]` AddressMask** _(Key)_: The address mask for the cluster network in
   the format '255.255.255.0'.
 * **`[String]` Name** _(Write)_: The name of the cluster network. If the cluster
   network name is not in desired state it will be renamed to match this name.
@@ -132,7 +132,7 @@ The cluster network role can be set to either the value 0, 1 or 3.
 3 = Allow cluster network communication and client connectivity
 
 See this article for more information about cluster network role values;
-https://technet.microsoft.com/en-us/library/dn550728(v=ws.11).aspx
+[Configuring Windows Failover Cluster Networks](https://blogs.technet.microsoft.com/askcore/2014/02/19/configuring-windows-failover-cluster-networks/)
 
 #### Examples for xClusterNetwork
 

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -1,0 +1,191 @@
+﻿Describe 'CommonResourceHelper Unit Tests' {
+    BeforeAll {
+        # Import the CommonResourceHelper module to test
+        $dscResourcesFolderFilePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) `
+                                                -ChildPath 'DscResources'
+
+        Import-Module -Name (Join-Path -Path $dscResourcesFolderFilePath `
+                                       -ChildPath 'CommonResourceHelper.psm1') -Force
+    }
+
+    InModuleScope 'CommonResourceHelper' {
+        Describe 'Get-LocalizedData' {
+            $mockTestPath = {
+                return $mockTestPathReturnValue
+            }
+
+            $mockImportLocalizedData = {
+                $BaseDirectory | Should Be $mockExpectedLanguagePath
+            }
+
+            BeforeEach {
+                Mock -CommandName Test-Path -MockWith $mockTestPath -Verifiable
+                Mock -CommandName Import-LocalizedData -MockWith $mockImportLocalizedData -Verifiable
+            }
+
+            Context 'When loading localized data for Swedish' {
+                $mockExpectedLanguagePath = 'sv-SE'
+                $mockTestPathReturnValue = $true
+
+                It 'Should call Import-LocalizedData with sv-SE language' {
+                    Mock -CommandName Join-Path -MockWith {
+                        return 'sv-SE'
+                    } -Verifiable
+
+                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Join-Path -Exactly -Times 2 -Scope It
+                    Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Import-LocalizedData -Exactly -Times 1 -Scope It
+                }
+
+                $mockExpectedLanguagePath = 'en-US'
+                $mockTestPathReturnValue = $false
+
+                It 'Should call Import-LocalizedData and fallback to en-US if sv-SE language does not exist' {
+                    Mock -CommandName Join-Path -MockWith {
+                        return $ChildPath
+                    } -Verifiable
+
+                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Join-Path -Exactly -Times 3 -Scope It
+                    Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Import-LocalizedData -Exactly -Times 1 -Scope It
+                }
+
+                Context 'When $ScriptRoot is set to a path' {
+                    $mockExpectedLanguagePath = 'sv-SE'
+                    $mockTestPathReturnValue = $true
+
+                    It 'Should call Import-LocalizedData with sv-SE language' {
+                        Mock -CommandName Join-Path -MockWith {
+                            return 'sv-SE'
+                        } -Verifiable
+
+                        { Get-LocalizedData -ResourceName 'DummyResource' -ScriptRoot '.' } | Should Not Throw
+
+                        Assert-MockCalled -CommandName Join-Path -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Import-LocalizedData -Exactly -Times 1 -Scope It
+                    }
+
+                    $mockExpectedLanguagePath = 'en-US'
+                    $mockTestPathReturnValue = $false
+
+                    It 'Should call Import-LocalizedData and fallback to en-US if sv-SE language does not exist' {
+                        Mock -CommandName Join-Path -MockWith {
+                            return $ChildPath
+                        } -Verifiable
+
+                        { Get-LocalizedData -ResourceName 'DummyResource' -ScriptRoot '.' } | Should Not Throw
+
+                        Assert-MockCalled -CommandName Join-Path -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Import-LocalizedData -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When loading localized data for English' {
+                Mock -CommandName Join-Path -MockWith {
+                    return 'en-US'
+                } -Verifiable
+
+                $mockExpectedLanguagePath = 'en-US'
+                $mockTestPathReturnValue = $true
+
+                It 'Should call Import-LocalizedData with en-US language' {
+                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should Not Throw
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'New-InvalidResultException' {
+            Context 'When calling with Message parameter only' {
+                It 'Should throw the correct error' {
+                    $mockErrorMessage = 'Mocked error'
+
+                    { New-InvalidResultException -Message $mockErrorMessage } | Should Throw $mockErrorMessage
+                }
+            }
+
+            Context 'When calling with both the Message and ErrorRecord parameter' {
+                It 'Should throw the correct error' {
+                    $mockErrorMessage = 'Mocked error'
+                    $mockExceptionErrorMessage = 'Mocked exception error message'
+
+                    $mockException = New-Object System.Exception $mockExceptionErrorMessage
+                    $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
+
+                    { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.Exception: Mocked error ---> System.Exception: Mocked exception error message'
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'New-ObjectNotFoundException' {
+            Context 'When calling with Message parameter only' {
+                It 'Should throw the correct error' {
+                    $mockErrorMessage = 'Mocked error'
+
+                    { New-ObjectNotFoundException -Message $mockErrorMessage } | Should Throw $mockErrorMessage
+                }
+            }
+
+            Context 'When calling with both the Message and ErrorRecord parameter' {
+                It 'Should throw the correct error' {
+                    $mockErrorMessage = 'Mocked error'
+                    $mockExceptionErrorMessage = 'Mocked exception error message'
+
+                    $mockException = New-Object System.Exception $mockExceptionErrorMessage
+                    $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
+
+                    { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.Exception: Mocked error ---> System.Exception: Mocked exception error message'
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'New-InvalidOperationException' {
+            Context 'When calling with Message parameter only' {
+                It 'Should throw the correct error' {
+                    $mockErrorMessage = 'Mocked error'
+
+                    { New-InvalidOperationException -Message $mockErrorMessage } | Should Throw $mockErrorMessage
+                }
+            }
+
+            Context 'When calling with both the Message and ErrorRecord parameter' {
+                It 'Should throw the correct error' {
+                    $mockErrorMessage = 'Mocked error'
+                    $mockExceptionErrorMessage = 'Mocked exception error message'
+
+                    $mockException = New-Object System.Exception $mockExceptionErrorMessage
+                    $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
+
+                    { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.InvalidOperationException: Mocked error ---> System.Exception: Mocked exception error message'
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'New-InvalidArgumentException' {
+            Context 'When calling with both the Message and ArgumentName parameter' {
+                It 'Should throw the correct error' {
+                    $mockErrorMessage = 'Mocked error'
+                    $mockArgumentName = 'MockArgument'
+
+                    { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should Throw 'Parameter name: MockArgument'
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+    }
+}

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -120,7 +120,7 @@
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.Exception: Mocked error ---> System.Exception: Mocked exception error message'
+                    { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -144,7 +144,7 @@
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.Exception: Mocked error ---> System.Exception: Mocked exception error message'
+                    { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -168,7 +168,7 @@
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.InvalidOperationException: Mocked error ---> System.Exception: Mocked exception error message'
+                    { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.InvalidOperationException: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -181,7 +181,7 @@
                     $mockErrorMessage = 'Mocked error'
                     $mockArgumentName = 'MockArgument'
 
-                    { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should Throw 'Parameter name: MockArgument'
+                    { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should Throw ('Parameter name: {0}' -f $mockArgumentName)
                 }
             }
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xFailOverCluster
  - Added a common resource helper module with helper functions for localization.
    - Added helper functions; Get-LocalizedData, New-InvalidResultException, New-ObjectNotFoundException, InvalidOperationException and InvalidArgumentException.
  - Fixed lint error MD034 and fixed typos in README.md.
- Changes to xClusterDisk
  - Enabled localization for all strings (issue #84).
- Changes to xClusterPreferredOwner
  - Replace an URL which describes more generic the Role setting for xClusterNetwork.

**This Pull Request (PR) fixes the following issues:**
Fixes #84 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/111)
<!-- Reviewable:end -->
