### PR TITLE
xClusterDisk: Fixed a data type that was not fully qualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
     method and instead added logic so that Set-TargetResource evaluates if it
     should remove a disk ([issue #90](https://github.com/PowerShell/xFailOverCluster/issues/90)).
   - Changed the code to be more aligned with the style guideline.
+    - Fixed a data type that was not fully qualified.
   - Added examples ([issue #46](https://github.com/PowerShell/xFailOverCluster/issues/46))
     - 1-AddClusterDisk.ps1
     - 2-RemoveClusterDisk.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+<<<<<<< HEAD
 - Changes to xFailOverCluster
   - Added a common resource helper module with helper functions for localization.
     - Added helper functions; Get-LocalizedData, New-InvalidResultException,
@@ -15,6 +16,10 @@
     generic description of the possible settings for the Role parameter. The
     previous URL was still correct but focused on Hyper-V in particular.
   - Fixed typos in parameter descriptions in README.md.
+=======
+- Changes to xClusterDisk
+  - Fixed the OutputType data type that was not fully qualified.
+>>>>>>> Updated CHANGELOG.md
 
 ## 1.7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-<<<<<<< HEAD
 - Changes to xFailOverCluster
   - Added a common resource helper module with helper functions for localization.
     - Added helper functions; Get-LocalizedData, New-InvalidResultException,
@@ -11,15 +10,12 @@
   - Fixed lint error MD034 and fixed typos in README.md.
 - Changes to xClusterDisk
   - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
+  - Fixed the OutputType data type that was not fully qualified.
 - Changes to xClusterNetwork
   - Replaced the URL for the parameter Role in README.md. The new URL is a more
     generic description of the possible settings for the Role parameter. The
     previous URL was still correct but focused on Hyper-V in particular.
   - Fixed typos in parameter descriptions in README.md.
-=======
-- Changes to xClusterDisk
-  - Fixed the OutputType data type that was not fully qualified.
->>>>>>> Updated CHANGELOG.md
 
 ## 1.7.0.0
 
@@ -99,7 +95,6 @@
     method and instead added logic so that Set-TargetResource evaluates if it
     should remove a disk ([issue #90](https://github.com/PowerShell/xFailOverCluster/issues/90)).
   - Changed the code to be more aligned with the style guideline.
-    - Fixed a data type that was not fully qualified.
   - Added examples ([issue #46](https://github.com/PowerShell/xFailOverCluster/issues/46))
     - 1-AddClusterDisk.ps1
     - 2-RemoveClusterDisk.ps1

--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
@@ -13,7 +13,7 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xClusterDisk'
 function Get-TargetResource
 {
     [CmdletBinding()]
-    [OutputType([Hashtable])]
+    [OutputType([System.Collections.Hashtable])]
     param
     (
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xClusterDisk
  - Fixed a data type that was not fully qualified.

**This Pull Request (PR) fixes the following issues:**
Missed this when trying to align this resource against the style guideline. 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/112)
<!-- Reviewable:end -->
