### PR TITLE
xCluster: Allow cluster to be assigned IP address from a DHCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Changes to xClusterNetwork
   - Updated readme to describe process for adding and removing additional networks on clusters
 - Changes to xCluster
-  - Allow StaticIPAddress to be unspecified (issue #109). Should fallback to DHCP.
+  - Allow cluster to be assigned IP address from a DHCP ([issue #109](https://github.com/PowerShell/xFailOverCluster/issues/109)).
+    When parameter StaticIPAddress is not specified then cluster will be configured
+    to use IP address from a DHCP.
 
 ## 1.8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Update Pester syntax to v4
 - Changes to xClusterNetwork
   - Updated readme to describe process for adding and removing additional networks on clusters
+- Changes to xCluster
+  - Allow StaticIPAddress to be unspecified (issue #109). Should fallback to DHCP.
 
 ## 1.8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Allow the cluster to be assigned an IP address from a DHCP ([issue #109](https://github.com/PowerShell/xFailOverCluster/issues/109)).
     When the parameter StaticIPAddress is not specified then the cluster will be
     configured to use an IP address from a DHCP.
+  - Get-TargetResource now correctly returns the IP address instead of throwing
+    and error ([issue #28](https://github.com/PowerShell/xFailOverCluster/issues/28)).
 
 ## 1.8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 - Changes to xClusterNetwork
   - Updated readme to describe process for adding and removing additional networks on clusters
 - Changes to xCluster
-  - Allow cluster to be assigned IP address from a DHCP ([issue #109](https://github.com/PowerShell/xFailOverCluster/issues/109)).
-    When parameter StaticIPAddress is not specified then cluster will be configured
-    to use IP address from a DHCP.
+  - Allow the cluster to be assigned an IP address from a DHCP ([issue #109](https://github.com/PowerShell/xFailOverCluster/issues/109)).
+    When the parameter StaticIPAddress is not specified then the cluster will be
+    configured to use an IP address from a DHCP.
 
 ## 1.8.0.0
 

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -25,7 +25,7 @@ function Get-TargetResource
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [System.String]
         $StaticIPAddress,
 

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -54,7 +54,7 @@ function Get-TargetResource
             New-ObjectNotFoundException -Message $errorMessage
         }
 
-        $address = Get-ClusterGroup -Cluster $Name -Name 'Cluster IP Address' | Get-ClusterParameter -Name 'Address'
+        $address = Get-ClusterGroup -Cluster $Name -Name 'Cluster IP Address' -ErrorAction SilentlyContinue | Get-ClusterParameter -Name 'Address' -ErrorAction SilentlyContinue
     }
     finally
     {
@@ -103,7 +103,7 @@ function Set-TargetResource
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [System.String]
         $StaticIPAddress,
 
@@ -145,7 +145,14 @@ function Set-TargetResource
         {
             Write-Verbose -Message ($script:localizedData.ClusterAbsent -f $Name)
 
-            New-Cluster -Name $Name -Node $env:COMPUTERNAME -StaticAddress $StaticIPAddress -NoStorage -Force -ErrorAction Stop
+            if ($StaticIPAddress)
+            {
+                New-Cluster -Name $Name -Node $env:COMPUTERNAME -StaticAddress $StaticIPAddress -NoStorage -Force -ErrorAction Stop
+            }
+            else
+            {
+                New-Cluster -Name $Name -Node $env:COMPUTERNAME -NoStorage -Force -ErrorAction Stop
+            }
 
             if ( -not (Get-Cluster))
             {

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -25,7 +25,7 @@ function Get-TargetResource
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [System.String]
         $StaticIPAddress,
 
@@ -103,7 +103,7 @@ function Set-TargetResource
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [System.String]
         $StaticIPAddress,
 
@@ -233,7 +233,7 @@ function Test-TargetResource
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [System.String]
         $StaticIPAddress,
 

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -233,7 +233,7 @@ function Test-TargetResource
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [System.String]
         $StaticIPAddress,
 

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -10,9 +10,6 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xCluster'
     .PARAMETER Name
         Name of the failover cluster.
 
-    .PARAMETER StaticIPAddress
-        Static IP Address of the failover cluster.
-
     .PARAMETER DomainAdministratorCredential
         Credential used to create the failover cluster in Active Directory.
 #>
@@ -24,10 +21,6 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
-
-        [Parameter()]
-        [System.String]
-        $StaticIPAddress,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
@@ -208,6 +201,7 @@ function Set-TargetResource
 
     .PARAMETER StaticIPAddress
         Static IP Address of the failover cluster.
+        Not used in Test-TargetResource.
 
     .PARAMETER DomainAdministratorCredential
         Credential used to create the failover cluster in Active Directory.

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -47,7 +47,8 @@ function Get-TargetResource
             New-ObjectNotFoundException -Message $errorMessage
         }
 
-        $address = Get-ClusterGroup -Cluster $Name -Name 'Cluster IP Address' -ErrorAction SilentlyContinue | Get-ClusterParameter -Name 'Address' -ErrorAction SilentlyContinue
+        # This will return the IP address regardless if using Static IP or DHCP.
+        $address = Get-ClusterResource -Cluster $Name -Name 'Cluster IP Address' | Get-ClusterParameter -Name 'Address'
     }
     finally
     {

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -4,7 +4,7 @@
 class MSFT_xCluster : OMI_BaseResource
 {
     [key, Description("Name of the Cluster")] string Name;
-    [required, Description("StaticIPAddress of the Cluster")] string StaticIPAddress;
+    [Description("StaticIPAddress of the Cluster")] string StaticIPAddress;
     
     [required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] 
     String DomainAdministratorCredential;

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -1,11 +1,9 @@
 #pragma namespace("\\\\.\\root\\microsoft\\windows\\DesiredStateConfiguration")
 
-[ClassVersion("1.0.0"), FriendlyName("xCluster")] 
+[ClassVersion("1.0.0"), FriendlyName("xCluster")]
 class MSFT_xCluster : OMI_BaseResource
 {
-    [key, Description("Name of the Cluster")] string Name;
-    [write, Description("StaticIPAddress of the Cluster")] string StaticIPAddress;
-    
-    [required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] 
-    String DomainAdministratorCredential;
+    [Key, Description("Name of the Cluster")] String Name;
+    [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
+    [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
 };

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -4,7 +4,7 @@
 class MSFT_xCluster : OMI_BaseResource
 {
     [key, Description("Name of the Cluster")] string Name;
-    [Description("StaticIPAddress of the Cluster")] string StaticIPAddress;
+    [write, Description("StaticIPAddress of the Cluster")] string StaticIPAddress;
     
     [required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] 
     String DomainAdministratorCredential;

--- a/Examples/Resources/xCluster/1-CreateFirstNodeOfAFailoverCluster.ps1
+++ b/Examples/Resources/xCluster/1-CreateFirstNodeOfAFailoverCluster.ps1
@@ -1,6 +1,6 @@
 <#
 .EXAMPLE
-    This example shows how to create the a failover cluster on the first node.
+    This example shows how to create the failover cluster on the first node.
 #>
 
 Configuration Example

--- a/Examples/Resources/xCluster/2-JoinAdditionalNodeToFailoverCluster.ps1
+++ b/Examples/Resources/xCluster/2-JoinAdditionalNodeToFailoverCluster.ps1
@@ -1,6 +1,6 @@
 <#
 .EXAMPLE
-    This example shows how to add an additional node to the a failover cluster.
+    This example shows how to add an additional node to the failover cluster.
 #>
 
 Configuration Example

--- a/Examples/Resources/xCluster/4-CreateFirstNodeOfAFailoverClusterWithDHCP.ps1
+++ b/Examples/Resources/xCluster/4-CreateFirstNodeOfAFailoverClusterWithDHCP.ps1
@@ -1,0 +1,52 @@
+<#
+.EXAMPLE
+    This example shows how to create the failover cluster on the first node
+    using DHCP to assign the IP address to the cluster.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $ActiveDirectoryAdministratorCredential
+    )
+
+    Import-DscResource -ModuleName xFailOverCluster
+
+    Node localhost
+    {
+        WindowsFeature AddFailoverFeature
+        {
+            Ensure = 'Present'
+            Name   = 'Failover-clustering'
+        }
+
+        WindowsFeature AddRemoteServerAdministrationToolsClusteringPowerShellFeature
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-Clustering-PowerShell'
+            DependsOn = '[WindowsFeature]AddFailoverFeature'
+        }
+
+        WindowsFeature AddRemoteServerAdministrationToolsClusteringCmdInterfaceFeature
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-Clustering-CmdInterface'
+            DependsOn = '[WindowsFeature]AddRemoteServerAdministrationToolsClusteringPowerShellFeature'
+        }
+
+        xCluster CreateCluster
+        {
+            Name                          = 'Cluster01'
+
+            <#
+                This user must have the permission to create the CNO (Cluster Name Object) in Active Directory,
+                unless it is prestaged.
+            #>
+            DomainAdministratorCredential = $ActiveDirectoryAdministratorCredential
+
+            DependsOn                     = '[WindowsFeature]AddRemoteServerAdministrationToolsClusteringCmdInterfaceFeature'
+        }
+    }
+}

--- a/Examples/Resources/xCluster/5-JoinAdditionalNodeToFailoverClusterWithDHCP.ps1
+++ b/Examples/Resources/xCluster/5-JoinAdditionalNodeToFailoverClusterWithDHCP.ps1
@@ -1,0 +1,54 @@
+<#
+.EXAMPLE
+    This example shows how to add an additional node to the failover cluster
+    when the cluster was assigned an IP address from a DHCP.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $ActiveDirectoryAdministratorCredential
+    )
+
+    Import-DscResource -ModuleName xFailOverCluster
+
+    Node localhost
+    {
+        WindowsFeature AddFailoverFeature
+        {
+            Ensure = 'Present'
+            Name   = 'Failover-clustering'
+        }
+
+        WindowsFeature AddRemoteServerAdministrationToolsClusteringPowerShellFeature
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-Clustering-PowerShell'
+            DependsOn = '[WindowsFeature]AddFailoverFeature'
+        }
+
+        WindowsFeature AddRemoteServerAdministrationToolsClusteringCmdInterfaceFeature
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-Clustering-CmdInterface'
+            DependsOn = '[WindowsFeature]AddRemoteServerAdministrationToolsClusteringPowerShellFeature'
+        }
+
+        xWaitForCluster WaitForCluster
+        {
+            Name             = 'Cluster01'
+            RetryIntervalSec = 10
+            RetryCount       = 60
+            DependsOn        = '[WindowsFeature]AddRemoteServerAdministrationToolsClusteringCmdInterfaceFeature'
+        }
+
+        xCluster JoinSecondNodeToCluster
+        {
+            Name                          = 'Cluster01'
+            DomainAdministratorCredential = $ActiveDirectoryAdministratorCredential
+            DependsOn                     = '[xWaitForCluster]WaitForCluster'
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ the target node ($env:COMPUTERNAME) to the cluster.
 #### Parameters for xCluster
 
 * **`[String]` Name** _(Key)_: Name of the failover cluster.
-* **`[String]` StaticIPAddress** _(Required)_: Static IP Address of the failover
-  cluster.
+* **`[String]` StaticIPAddress** _(Required)_: The static IP address of the failover
+  cluster. If this is not specified then the IP address will be assigned from a
+  DHCP.
 * **`[String]` DomainAdministratorCredential** _(Required)_: Credential used to
   create the failover cluster in Active Directory.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ the target node ($env:COMPUTERNAME) to the cluster.
 * [Create first node of a failover cluster](/Examples/Resources/xCluster/1-CreateFirstNodeOfAFailoverCluster.ps1)
 * [Join additional node to a failover cluster](/Examples/Resources/xCluster/2-JoinAdditionalNodeToFailoverCluster.ps1)
 * [Create failover cluster with two nodes](/Examples/Resources/xCluster/3-CreateFailoverClusterWithTwoNodes.ps1)
+* [Create first node of a failover cluster with DHCP](/Examples/Resources/xCluster/4-CreateFirstNodeOfAFailoverClusterWithDHCP.ps1)
+* [Join additional node to a failover cluster with DHCP](/Examples/Resources/xCluster/5-JoinAdditionalNodeToFailoverClusterWithDHCP.ps1)
 
 ### xClusterDisk
 

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -100,7 +100,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
             }
 
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
 
         Describe 'New-InvalidResultException' {
@@ -124,7 +124,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
             }
 
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
 
         Describe 'New-ObjectNotFoundException' {
@@ -148,7 +148,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
             }
 
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
 
         Describe 'New-InvalidOperationException' {
@@ -172,7 +172,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
             }
 
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
 
         Describe 'New-InvalidArgumentException' {
@@ -185,7 +185,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
             }
 
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
     }
 }

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -75,16 +75,17 @@ try
             $Name -eq $mockDefaultParameters.Name -and $Domain -eq $mockDomainName
         }
 
-        $mockGetClusterGroup = {
+        $mockGetClusterResource = {
             return @{
-                Name      = 'Cluster Group'
-                OwnerNode = 'Node1'
-                State     = 'Online'
+                Name         = 'Cluster IP Address'
+                OwnerNode    = 'Cluster Group'
+                State        = 'Online'
+                ResourceType = 'IP Address'
             }
         }
 
-        $mockGetClusterGroup_ParameterFilter = {
-            $Cluster -eq $mockClusterName
+        $mockGetClusterResource_ParameterFilter = {
+            $Cluster -eq $mockClusterName -and $Name -eq 'Cluster IP Address'
         }
 
         $mockGetClusterParameter = {
@@ -95,7 +96,7 @@ try
             }
         }
 
-       $mockGetClusterNode = {
+        $mockGetClusterNode = {
             return @(
                 @{
                     Name  = $mockServerName
@@ -107,10 +108,10 @@ try
         $mockNewObjectWindowsIdentity = {
             return [PSCustomObject] @{} |
                 Add-Member -MemberType ScriptMethod -Name Impersonate -Value {
-                    return [PSCustomObject] @{} |
-                        Add-Member -MemberType ScriptMethod -Name Undo -Value {} -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name Dispose -Value {} -PassThru -Force
-                } -PassThru -Force
+                return [PSCustomObject] @{} |
+                    Add-Member -MemberType ScriptMethod -Name Undo -Value {} -PassThru |
+                    Add-Member -MemberType ScriptMethod -Name Dispose -Value {} -PassThru -Force
+            } -PassThru -Force
         }
 
         $mockNewObjectWindowsIdentity_ParameterFilter = {
@@ -189,7 +190,7 @@ try
                 BeforeEach {
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
                     Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
-                    Mock -CommandName Get-ClusterGroup -MockWith $mockGetClusterGroup -ParameterFilter $mockGetClusterGroup_ParameterFilter -Verifiable
+                    Mock -CommandName Get-ClusterResource -MockWith $mockGetClusterResource -ParameterFilter $mockGetClusterResource_ParameterFilter -Verifiable
                     Mock -CommandName Get-ClusterParameter -MockWith $mockGetClusterParameter -Verifiable
                 }
 

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -207,7 +207,7 @@ try
                     $getTargetResourceResult.StaticIPAddress  | Should -Be $mockDefaultParameters.StaticIPAddress
                 }
 
-                Assert-VerifiableMocks
+                Assert-VerifiableMock
             }
         }
 
@@ -382,7 +382,7 @@ try
                         Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
         }
@@ -424,7 +424,7 @@ try
                         $testTargetResourceResult | Should -Be $false
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
 
                 Context 'When the Get-Cluster throws an error' {
@@ -437,7 +437,7 @@ try
                         $testTargetResourceResult | Should -Be $false
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
 
                 Context 'When the node does not exist' {
@@ -450,7 +450,7 @@ try
                         $testTargetResourceResult | Should -Be $false
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
 
                 Context 'When the node do exist, but is down' {
@@ -467,7 +467,7 @@ try
                         $testTargetResourceResult | Should -Be $false
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
 
             }
@@ -489,7 +489,7 @@ try
                         $testTargetResourceResult | Should -Be $true
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
         }

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -263,7 +263,7 @@ try
                             }
                         }
 
-                        Context 'When assigned IP-address from DHCP' {
+                        Context 'When assigned IP address from DHCP' {
                             It 'Should call New-Cluster cmdlet using StaticAddress parameter' {
                                 $mockTestParameters = $mockDefaultParameters.Clone()
                                 $mockTestParameters.Remove('StaticIPAddress')

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -150,6 +150,9 @@ try
 
         Describe 'xCluster\Get-TargetResource' {
             BeforeAll {
+                $mockGetTargetResourceParameters = $mockDefaultParameters.Clone()
+                $mockGetTargetResourceParameters.Remove('StaticIPAddress')
+
                 Mock -CommandName Add-Type -MockWith {
                     return $mockLibImpersonationObject
                 }
@@ -165,7 +168,7 @@ try
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
-                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
+                    { Get-TargetResource @mockGetTargetResourceParameters } | Should -Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -178,7 +181,7 @@ try
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     $mockCorrectErrorRecord = Get-ObjectNotFoundException -Message ($script:localizedData.ClusterNameNotFound -f $mockClusterName)
-                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
+                    { Get-TargetResource @mockGetTargetResourceParameters } | Should -Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -194,12 +197,12 @@ try
                 $mockDynamicServerName = $mockServerName
 
                 It 'Returns a [System.Collection.Hashtable] type' {
-                    $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
+                    $getTargetResourceResult = Get-TargetResource @mockGetTargetResourceParameters
                     $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                 }
 
                 It 'Returns current configuration' {
-                    $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
+                    $getTargetResourceResult = Get-TargetResource @mockGetTargetResourceParameters
                     $getTargetResourceResult.Name             | Should -Be $mockDefaultParameters.Name
                     $getTargetResourceResult.StaticIPAddress  | Should -Be $mockDefaultParameters.StaticIPAddress
                 }

--- a/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
@@ -82,7 +82,7 @@ try
                     $getTargetResourceResult.RetryCount        | Should -Be $mockDefaultParameters.RetryCount
                 }
 
-                Assert-VerifiableMocks
+                Assert-VerifiableMock
             }
         }
 
@@ -119,7 +119,7 @@ try
                             { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
                         }
 
-                        Assert-VerifiableMocks
+                        Assert-VerifiableMock
                     }
                 }
             }
@@ -137,7 +137,7 @@ try
                         { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
         }
@@ -173,7 +173,7 @@ try
                             $testTargetResourceResult | Should -Be $false
                         }
 
-                        Assert-VerifiableMocks
+                        Assert-VerifiableMock
                     }
 
                     Context 'When Get-Cluster returns nothing' {
@@ -191,7 +191,7 @@ try
                             $testTargetResourceResult | Should -Be $false
                         }
 
-                        Assert-VerifiableMocks
+                        Assert-VerifiableMock
                     }
                 }
             }
@@ -209,7 +209,7 @@ try
                         $testTargetResourceResult | Should -Be $true
                     }
 
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
         }


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xCluster
  - Allow cluster to be assigned IP address from a DHCP (issue #109).
    When parameter StaticIPAddress is not specified then cluster will be configured
    to use IP address from a DHCP.

**This Pull Request (PR) fixes the following issues:**
Fixes #109 
Fixes #28 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/113)
<!-- Reviewable:end -->

