### PR TITLE
xClusterPreferredOwner: Enabled localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@
     - 3-SetQuorumToNodeAndFileShareMajority.ps1
     - 4-SetQuorumToDiskOnly.ps1
   - Added links to examples from README.md.
+- Changes to xClusterPreferredOwner
+  - Enabled localization for all strings ([issue #86](https://github.com/PowerShell/xFailOverCluster/issues/86)).
+  - Fixed typo in the returned hash table from Get-TargetResource.
 
 ## 1.7.0.0
 

--- a/DSCResources/MSFT_xClusterPreferredOwner/en-US/MSFT_xClusterPreferredOwner.strings.psd1
+++ b/DSCResources/MSFT_xClusterPreferredOwner/en-US/MSFT_xClusterPreferredOwner.strings.psd1
@@ -1,0 +1,15 @@
+# Localized resources for xClusterPreferredOwner
+
+ConvertFrom-StringData @'
+    GetOwnerInformationForCluster = Retrieving owner information for cluster {0}.
+    GetOwnerInformationForClusterGroup = Retrieving owner information for cluster role/group {0}.
+    GetOwnerInformationForClusterResource = Retrieving owner information for cluster resource {0}.
+    GetAllNodesOfCluster = Retrieving all nodes from cluster {0}.
+    SetOwnerForClusterGroup = Setting owners for cluster role/group {0} to {1}.
+    SetOwnerForClusterResource = Setting owners for cluster resource {0} to {1}.
+    MoveClusterGroup = Moving cluster role/group {0} to node {1}.
+    RemoveOwnerFromClusterGroup = Removing owners {1} from cluster role/group {0}.
+    TestOwnerInformationForCluster = Testing Owner information for cluster {0}.
+    WasFoundAsPossibleOwner = {0} was found as possible owner.
+    WasNotFoundAsPossibleOwner = {0} was NOT found as possible owner.
+'@


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xClusterPreferredOwner
  - Enabled localization for all strings ([issue #86](https://github.com/PowerShell/xFailOverCluster/issues/86)).
  - Fixed typo in the returned hash table from Get-TargetResource.

**This Pull Request (PR) fixes the following issues:**
Fixes #86 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/117)
<!-- Reviewable:end -->
