### PR TITLE
xCluster: Enabled localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   - Minor style change in tests. Removed '-' in front of '-Be', '-Not', '-Throw',
     etc.
   - Enabled localization for all strings ([issue #83](https://github.com/PowerShell/xFailOverCluster/issues/83)).
+  - Added tests to improve code coverage.
 - Changes to xWaitForCluster
   - Refactored the unit test for this resource to use stubs and increase coverage
     ([issue #78](https://github.com/PowerShell/xFailOverCluster/issues/78)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
     - Removed Byte Order Mark (BOM) from the files; CommonResourceHelper.Tests.ps1,
       MSFT\_xCluster.Tests.ps1, MSFT\_xClusterDisk.Tests.ps1,
       MSFT\_xClusterPreferredOwner.Tests.ps1, MSFT_xWaitForCluster.Tests.ps1.
+  - Added common test helper functions to help test the throwing of localized error strings.
+    - Get-InvalidArgumentRecord
+    - Get-InvalidOperationRecord
+    - Get-ObjectNotFoundException
+    - Get-InvalidResultException.
 - Changes to xClusterDisk
   - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
   - Fixed the OutputType data type that was not fully qualified.
@@ -27,6 +32,7 @@
     Get-CimInstance ([issue #49](https://github.com/PowerShell/xFailOverCluster/issues/49)).
   - Minor style change in tests. Removed '-' in front of '-Be', '-Not', '-Throw',
     etc.
+  - Enabled localization for all strings ([issue #83](https://github.com/PowerShell/xFailOverCluster/issues/83)).
 - Changes to xWaitForCluster
   - Refactored the unit test for this resource to use stubs and increase coverage
     ([issue #78](https://github.com/PowerShell/xFailOverCluster/issues/78)).

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -1,3 +1,8 @@
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath 'CommonResourceHelper.psm1')
+
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xCluster'
+
 <#
     .SYNOPSIS
         Returns the current state of the failover cluster.
@@ -32,7 +37,8 @@ function Get-TargetResource
     $computerInformation = Get-CimInstance -ClassName Win32_ComputerSystem
     if (($null -eq $computerInformation) -or ($null -eq $computerInformation.Domain))
     {
-        throw 'Can''t find machine''s domain name'
+        $errorMessage = $script:localizedData.TargetNodeDomainMissing
+        New-InvalidOperationException -Message $errorMessage
     }
 
     try
@@ -42,7 +48,8 @@ function Get-TargetResource
         $cluster = Get-Cluster -Name $Name -Domain $computerInformation.Domain
         if ($null -eq $cluster)
         {
-            throw "Can't find the cluster $Name"
+            $errorMessage = $script:localizedData.ClusterNameNotFound -f $Name
+            New-ObjectNotFoundException -Message $errorMessage
         }
 
         $address = Get-ClusterGroup -Cluster $Name -Name 'Cluster IP Address' | Get-ClusterParameter -Name 'Address'
@@ -105,12 +112,13 @@ function Set-TargetResource
 
     $bCreate = $true
 
-    Write-Verbose -Message "Checking if Cluster $Name is present ..."
+    Write-Verbose -Message ($script:localizedData.CheckClusterPresent -f $Name)
 
     $computerInformation = Get-CimInstance -ClassName Win32_ComputerSystem
     if (($null -eq $computerInformation) -or ($null -eq $computerInformation.Domain))
     {
-        throw 'Can''t find machine''s domain name'
+        $errorMessage = $script:localizedData.TargetNodeDomainMissing
+        New-InvalidOperationException -Message $errorMessage
     }
 
     try
@@ -133,40 +141,41 @@ function Set-TargetResource
 
         if ($bCreate)
         {
-            Write-Verbose -Message "Cluster $Name is NOT present"
+            Write-Verbose -Message ($script:localizedData.ClusterAbsent -f $Name)
 
             New-Cluster -Name $Name -Node $env:COMPUTERNAME -StaticAddress $StaticIPAddress -NoStorage -Force -ErrorAction Stop
 
             if ( -not (Get-Cluster))
             {
-                throw 'Cluster creation failed. Please verify output of ''Get-Cluster'' command'
+                $errorMessage = $script:localizedData.FailedCreatingCluster
+                New-InvalidOperationException -Message $errorMessage
             }
 
-            Write-Verbose -Message "Created Cluster $Name"
+            Write-Verbose -Message ($script:localizedData.ClusterCreated -f $Name)
         }
         else
         {
-            Write-Verbose -Message "Add node to Cluster $Name ..."
+            $targetNodeName = $env:COMPUTERNAME
 
-            Write-Verbose -Message "Add-ClusterNode $env:COMPUTERNAME to cluster $Name"
+            Write-Verbose -Message ($script:localizedData.AddNodeToCluster -f $targetNodeName, $Name)
 
             $list = Get-ClusterNode -Cluster $Name
             foreach ($node in $list)
             {
-                if ($node.Name -eq $env:COMPUTERNAME)
+                if ($node.Name -eq $targetNodeName)
                 {
                     if ($node.State -eq 'Down')
                     {
-                        Write-Verbose -Message "Node $env:COMPUTERNAME was down, need remove it from the list."
+                        Write-Verbose -Message ($script:localizedData.RemoveOfflineNodeFromCluster -f $targetNodeName, $Name)
 
-                        Remove-ClusterNode -Name $env:COMPUTERNAME -Cluster $Name -Force
+                        Remove-ClusterNode -Name $targetNodeName -Cluster $Name -Force
                     }
                 }
             }
 
-            Add-ClusterNode -Name $env:COMPUTERNAME -Cluster $Name -NoStorage
+            Add-ClusterNode -Name $targetNodeName -Cluster $Name -NoStorage
 
-            Write-Verbose -Message "Added node to Cluster $Name"
+            Write-Verbose -Message ($script:localizedData.AddNodeToClusterSuccessful -f $targetNodeName, $Name)
         }
     }
     finally
@@ -226,12 +235,13 @@ function Test-TargetResource
 
     $returnValue = $false
 
-    Write-Verbose -Message "Checking if Cluster $Name is present ..."
+    Write-Verbose -Message ($script:localizedData.CheckClusterPresent -f $Name)
 
     $ComputerInfo = Get-CimInstance -ClassName Win32_ComputerSystem
     if (($null -eq $ComputerInfo) -or ($null -eq $ComputerInfo.Domain))
     {
-        throw "Can't find machine's domain name"
+        $errorMessage = $script:localizedData.TargetNodeDomainMissing
+        New-InvalidOperationException -Message $errorMessage
     }
 
     try
@@ -240,17 +250,19 @@ function Test-TargetResource
 
         $cluster = Get-Cluster -Name $Name -Domain $ComputerInfo.Domain
 
-        Write-Verbose -Message "Cluster $Name is present"
+        Write-Verbose -Message ($script:localizedData.ClusterPresent -f $Name)
 
         if ($cluster)
         {
-            Write-Verbose -Message "Checking if the node is in cluster $Name ..."
+            $targetNodeName = $env:COMPUTERNAME
+
+            Write-Verbose -Message ($script:localizedData.CheckClusterNodeIsUp -f $targetNodeName, $Name)
 
             $allNodes = Get-ClusterNode -Cluster $Name
 
             foreach ($node in $allNodes)
             {
-                if ($node.Name -eq $env:COMPUTERNAME)
+                if ($node.Name -eq $targetNodeName)
                 {
                     if ($node.State -eq 'Up')
                     {
@@ -258,7 +270,7 @@ function Test-TargetResource
                     }
                     else
                     {
-                        Write-Verbose -Message "Node is in cluster $Name but is NOT up, treat as NOT in cluster."
+                        Write-Verbose -Message ($script:localizedData.ClusterNodeIsDown -f $targetNodeName, $Name)
                     }
 
                     break
@@ -267,17 +279,17 @@ function Test-TargetResource
 
             if ($returnValue)
             {
-                Write-Verbose -Message "Node is in cluster $Name"
+                Write-Verbose -Message ($script:localizedData.ClusterNodePresent -f $targetNodeName, $Name)
             }
             else
             {
-                Write-Verbose -Message "Node is NOT in cluster $Name"
+                Write-Verbose -Message ($script:localizedData.ClusterNodeAbsent -f $targetNodeName, $Name)
             }
         }
     }
     catch
     {
-        Write-Verbose -Message "Cluster $Name is NOT present with Error $_.Message"
+        Write-Verbose -Message ($script:localizedData.ClusterAbsentWithError -f $Name, $_.Message)
     }
     finally
     {
@@ -361,7 +373,8 @@ function Set-ImpersonateAs
     }
     else
     {
-        throw "Can't Logon as User $($Credential.GetNetworkCredential().UserName)."
+        $errorMessage = $script:localizedData.UnableToImpersonateUser -f $Credential.GetNetworkCredential().UserName
+        New-InvalidOperationException -Message $errorMessage
     }
 
     $context, $userToken
@@ -392,6 +405,7 @@ function Close-UserToken
     $bLogin = $ImpersonateLib::CloseHandle($Token)
     if (-not $bLogin)
     {
-        throw 'Can''t close token'
+        $errorMessage = $script:localizedData.UnableToCloseToken
+        New-InvalidOperationException -Message $errorMessage
     }
 }

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -405,7 +405,7 @@ function Close-UserToken
     $bLogin = $ImpersonateLib::CloseHandle($Token)
     if (-not $bLogin)
     {
-        $errorMessage = $script:localizedData.UnableToCloseToken
+        $errorMessage = $script:localizedData.UnableToCloseToken -f $Token.ToString()
         New-InvalidOperationException -Message $errorMessage
     }
 }

--- a/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
+++ b/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
@@ -1,0 +1,21 @@
+# Localized resources for xCluster
+
+ConvertFrom-StringData @'
+    CheckClusterPresent = Checking if cluster {0} is present.
+    ClusterPresent = Cluster {0} is present.
+    ClusterAbsent = Cluster {0} is NOT present.
+    ClusterCreated = Created cluster {0}.
+    AddNodeToCluster = Adding node {0} to cluster {1}.
+    RemoveOfflineNodeFromCluster = Node {0} is down, need to remove it from the cluster {1}.
+    AddNodeToClusterSuccessful = Added node {0} to cluster {1}.
+    CheckClusterNodeIsUp = Checking if the node {0} is a member of the cluster {1}, and so that node status is 'Up'.
+    ClusterNodeIsDown = Node {0} is in the cluster {1} but the status is not 'Up'. Node will be treated as NOT being a member of the cluster {1}.
+    ClusterNodePresent = Cluster node {0} is a member of cluster {1}.
+    ClusterNodeAbsent = Cluster node {0} is NOT a member of cluster {1}.
+    ClusterAbsentWithError = Cluster {0} is NOT present with error: {1}
+    TargetNodeDomainMissing = Can't find the target node's domain name.
+    ClusterNameNotFound = Can't find the cluster {0}.
+    FailedCreatingCluster = Cluster creation failed. Please verify output of 'Get-Cluster' command.
+    UnableToImpersonateUser = Can't logon as user {0}.
+    UnableToCloseToken = Can't close impersonation token {0}.
+'@

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -15,12 +15,12 @@ function Get-InvalidArgumentRecord
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $ArgumentName
     )
 
@@ -60,7 +60,7 @@ function Get-InvalidOperationRecord
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter()]

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -1,0 +1,210 @@
+<#
+    .SYNOPSIS
+        Returns an invalid argument exception object
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ArgumentName
+        The name of the invalid argument that is causing this error to be thrown
+#>
+function Get-InvalidArgumentRecord
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Message,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ArgumentName
+    )
+
+    $argumentException = New-Object -TypeName 'ArgumentException' `
+                                    -ArgumentList @(
+                                        $Message,
+                                        $ArgumentName
+                                    )
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $argumentException,
+            $ArgumentName,
+            'InvalidArgument',
+            $null
+        )
+    }
+
+    return New-Object @newObjectParameters
+}
+
+<#
+    .SYNOPSIS
+        Returns an invalid operation exception object
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error
+#>
+function Get-InvalidOperationRecord
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Message,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord)
+    {
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' `
+                                                -ArgumentList @( $Message )
+    }
+    else
+    {
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' `
+                                                -ArgumentList @(
+                                                    $Message,
+                                                    $ErrorRecord.Exception
+                                                )
+    }
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $invalidOperationException.ToString(),
+            'MachineStateIncorrect',
+            'InvalidOperation',
+            $null
+        )
+    }
+
+    return New-Object @newObjectParameters
+}
+
+<#
+    .SYNOPSIS
+        Returns an object not found exception object
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error
+#>
+function Get-ObjectNotFoundException
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Message,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord)
+    {
+        $objectNotFoundException = New-Object -TypeName 'System.Exception' `
+                                              -ArgumentList @($Message)
+    }
+    else
+    {
+        $objectNotFoundException = New-Object -TypeName 'System.Exception' `
+                                              -ArgumentList @(
+                                                   $Message,
+                                                   $ErrorRecord.Exception
+                                               )
+    }
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $objectNotFoundException.ToString(),
+            'MachineStateIncorrect',
+            'ObjectNotFound',
+            $null
+            )
+    }
+
+    return New-Object @newObjectParameters
+}
+
+<#
+    .SYNOPSIS
+        Returns an invalid result exception object
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error
+#>
+function Get-InvalidResultException
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Message,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord)
+    {
+        $exception = New-Object -TypeName 'System.Exception' `
+                                -ArgumentList @($Message)
+    }
+    else
+    {
+        $exception = New-Object -TypeName 'System.Exception' `
+                                -ArgumentList @(
+                                    $Message,
+                                    $ErrorRecord.Exception
+                                )
+    }
+
+    $newObjectParameters = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @(
+            $exception.ToString(),
+            'MachineStateIncorrect',
+            'InvalidResult',
+            $null
+        )
+    }
+
+    return New-Object @newObjectParameters
+}
+
+Export-ModuleMember -Function @(
+    'Get-InvalidArgumentRecord'
+    'Get-InvalidOperationRecord'
+    'Get-ObjectNotFoundException'
+    'Get-InvalidResultException'
+)

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -23,6 +23,7 @@ $TestEnvironment = Initialize-TestEnvironment `
 function Invoke-TestSetup
 {
     Import-Module -Name (Join-Path -Path (Join-Path -Path (Join-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests') -ChildPath 'Unit') -ChildPath 'Stubs') -ChildPath 'FailoverClusters.stubs.psm1') -Global -Force
+    Import-Module -Name (Join-Path -Path (Join-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests') -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global -Force
 }
 
 function Invoke-TestCleanup
@@ -110,7 +111,12 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
+<<<<<<< HEAD
                     { Get-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
+=======
+                    $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
+                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
+>>>>>>> Changes to xCluster
                 }
             }
 
@@ -122,7 +128,12 @@ try
                     Mock -CommandName Get-Cluster -Verifiable
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
+<<<<<<< HEAD
                     { Get-TargetResource @mockDefaultParameters } | Should Throw ("Can't find the cluster {0}" -f $mockClusterName)
+=======
+                    $mockCorrectErrorRecord = Get-ObjectNotFoundException -Message ($script:localizedData.ClusterNameNotFound -f $mockClusterName)
+                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
+>>>>>>> Changes to xCluster
                 }
             }
 
@@ -160,7 +171,12 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
+<<<<<<< HEAD
                     { Set-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
+=======
+                    $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
+                    { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
+>>>>>>> Changes to xCluster
                 }
             }
 
@@ -215,7 +231,12 @@ try
                     It 'Should throw the correct error message' {
                         Mock -CommandName Get-Cluster
 
+<<<<<<< HEAD
                         { Set-TargetResource @mockDefaultParameters } | Should Throw 'Cluster creation failed. Please verify output of ''Get-Cluster'' command'
+=======
+                        $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.FailedCreatingCluster
+                        { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
+>>>>>>> Changes to xCluster
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -303,7 +324,8 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-                    { Test-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
+                    $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
+                    { Test-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
                 }
             }
 

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -111,12 +111,8 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-<<<<<<< HEAD
-                    { Get-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
-=======
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
-                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
->>>>>>> Changes to xCluster
+                    { Get-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -128,12 +124,8 @@ try
                     Mock -CommandName Get-Cluster -Verifiable
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-<<<<<<< HEAD
-                    { Get-TargetResource @mockDefaultParameters } | Should Throw ("Can't find the cluster {0}" -f $mockClusterName)
-=======
                     $mockCorrectErrorRecord = Get-ObjectNotFoundException -Message ($script:localizedData.ClusterNameNotFound -f $mockClusterName)
-                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
->>>>>>> Changes to xCluster
+                    { Get-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -171,12 +163,8 @@ try
 
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
-<<<<<<< HEAD
-                    { Set-TargetResource @mockDefaultParameters } | Should Throw "Can't find machine's domain name"
-=======
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
-                    { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
->>>>>>> Changes to xCluster
+                    { Set-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -231,12 +219,8 @@ try
                     It 'Should throw the correct error message' {
                         Mock -CommandName Get-Cluster
 
-<<<<<<< HEAD
-                        { Set-TargetResource @mockDefaultParameters } | Should Throw 'Cluster creation failed. Please verify output of ''Get-Cluster'' command'
-=======
                         $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.FailedCreatingCluster
-                        { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
->>>>>>> Changes to xCluster
+                        { Set-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xFailOverCluster
  - Added common test helper functions to help test the throwing of localized error strings.
    - Get-InvalidArgumentRecord
    - Get-InvalidOperationRecord
    - Get-ObjectNotFoundException
    - Get-InvalidResultException.
- Changes to xCluster
  - Enabled localization for all strings (issue #83).
  - Added tests to improve code coverage.

**This Pull Request (PR) fixes the following issues:**
Fixes #83 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/118)
<!-- Reviewable:end -->
