### PR TITLE
xFailOverCluster: Opt-in for script files common tests

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -1,5 +1,6 @@
 [
     "Common Tests - Validate Example Files",
     "Common Tests - Validate Markdown Files",
-    "Common Tests - Validate Module Files"
+    "Common Tests - Validate Module Files",
+    "Common Tests - Validate Script Files"
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - Fixed lint error MD034 and fixed typos in README.md.
   - Opt-in for module files common tests ([issue #119](https://github.com/PowerShell/xFailOverCluster/issues/119)).
     - Removed Byte Order Mark (BOM) from the files; CommonResourceHelper.psm1 and FailoverClusters.stubs.psm1.
+  - Opt-in for script files common tests ([issue #121](https://github.com/PowerShell/xFailOverCluster/issues/121)).
+    - Removed Byte Order Mark (BOM) from the files; CommonResourceHelper.Tests.ps1,
+      MSFT\_xCluster.Tests.ps1, MSFT\_xClusterDisk.Tests.ps1,
+      MSFT\_xClusterPreferredOwner.Tests.ps1.
 - Changes to xClusterDisk
   - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
   - Fixed the OutputType data type that was not fully qualified.

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe 'CommonResourceHelper Unit Tests' {
+Describe 'CommonResourceHelper Unit Tests' {
     BeforeAll {
         # Import the CommonResourceHelper module to test
         $dscResourcesFolderFilePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) `

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xFailOverCluster'
+$script:DSCModuleName = 'xFailOverCluster'
 $script:DSCResourceName = 'MSFT_xCluster'
 
 #region HEADER

--- a/Tests/Unit/MSFT_xClusterDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterDisk.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xFailOverCluster'
+$script:DSCModuleName = 'xFailOverCluster'
 $script:DSCResourceName = 'MSFT_xClusterDisk'
 
 #region Header

--- a/Tests/Unit/MSFT_xClusterPreferredOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterPreferredOwner.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xFailOverCluster'
+$script:DSCModuleName = 'xFailOverCluster'
 $script:DSCResourceName = 'MSFT_xClusterPreferredOwner'
 
 #region Header


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xFailOverCluster
  - Opt-in for script files common tests (issue #121).
    - Removed Byte Order Mark (BOM) from the files; CommonResourceHelper.Tests.ps1,
      MSFT\_xCluster.Tests.ps1, MSFT\_xClusterDisk.Tests.ps1,
      MSFT\_xClusterPreferredOwner.Tests.ps1.

**This Pull Request (PR) fixes the following issues:**
Fixes #121 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/122)
<!-- Reviewable:end -->
