### PR TITLE
xFailoverCluster: Removed Byte Order Mark (BOM) from script file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - Opt-in for script files common tests ([issue #121](https://github.com/PowerShell/xFailOverCluster/issues/121)).
     - Removed Byte Order Mark (BOM) from the files; CommonResourceHelper.Tests.ps1,
       MSFT\_xCluster.Tests.ps1, MSFT\_xClusterDisk.Tests.ps1,
-      MSFT\_xClusterPreferredOwner.Tests.ps1.
+      MSFT\_xClusterPreferredOwner.Tests.ps1, MSFT_xWaitForCluster.Tests.ps1.
 - Changes to xClusterDisk
   - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
   - Fixed the OutputType data type that was not fully qualified.

--- a/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xFailOverCluster'
+$script:DSCModuleName = 'xFailOverCluster'
 $script:DSCResourceName = 'MSFT_xWaitForCluster'
 
 #region HEADER


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xFailoverCluster
  - Removed Byte Order Mark (BOM) from the file; MSFT_xWaitForCluster.Tests.ps1.

**This Pull Request (PR) fixes the following issues:**
For some reason the tests did not fail on this in the PR. But failed after merge, when the dev branch was tested. :/

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/130)
<!-- Reviewable:end -->
