### PR TITLE
xFailOverCluster: Updated year to 2017 in license file and module manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - Get-InvalidOperationRecord
     - Get-ObjectNotFoundException
     - Get-InvalidResultException.
+  - Updated year to 2017 in license file and module manifest ([issue #131](https://github.com/PowerShell/xFailOverCluster/issues/131)).
 - Changes to xClusterDisk
   - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
   - Fixed the OutputType data type that was not fully qualified.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Microsoft Corporation.
+Copyright (c) 2017 Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/xFailOverCluster.psd1
+++ b/xFailOverCluster.psd1
@@ -8,7 +8,7 @@ Author = 'Microsoft Corporation'
 
 CompanyName = 'Microsoft Corporation'
 
-Copyright = '(c) 2014 Microsoft Corporation. All rights reserved.'
+Copyright = '(c) 2017 Microsoft Corporation. All rights reserved.'
 
 Description = 'Module containing DSC resources used to configure Failover Clusters.'
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xFailOverCluster
  - Updated year to 2017 in license file and module manifest (issue #131).

**This Pull Request (PR) fixes the following issues:**
Fixes #131 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/132)
<!-- Reviewable:end -->
