### PR TITLE
xCluster: Fixed random problem with tests failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
     etc.
   - Enabled localization for all strings ([issue #83](https://github.com/PowerShell/xFailOverCluster/issues/83)).
   - Added tests to improve code coverage.
+    - Fixed random problem with tests failing with error "Invalid token for
+      impersonation - it cannot be duplicated." ([issue #133](https://github.com/PowerShell/xFailOverCluster/issues/133)).
 - Changes to xWaitForCluster
   - Refactored the unit test for this resource to use stubs and increase coverage
     ([issue #78](https://github.com/PowerShell/xFailOverCluster/issues/78)).

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -104,6 +104,19 @@ try
             )
         }
 
+        $mockNewObjectWindowsIdentity = {
+            return [PSCustomObject] @{} |
+                Add-Member -MemberType ScriptMethod -Name Impersonate -Value {
+                    return [PSCustomObject] @{} |
+                        Add-Member -MemberType ScriptMethod -Name Undo -Value {} -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Dispose -Value {} -PassThru -Force
+                } -PassThru -Force
+        }
+
+        $mockNewObjectWindowsIdentity_ParameterFilter = {
+            $TypeName -eq 'Security.Principal.WindowsIdentity'
+        }
+
         $mockDefaultParameters = @{
             Name                          = $mockClusterName
             StaticIPAddress               = $mockStaticIpAddress
@@ -140,6 +153,8 @@ try
                 Mock -CommandName Add-Type -MockWith {
                     return $mockLibImpersonationObject
                 }
+
+                Mock -CommandName New-Object -MockWith $mockNewObjectWindowsIdentity -ParameterFilter $mockNewObjectWindowsIdentity_ParameterFilter -Verifiable
             }
 
             Context 'When the computers domain name cannot be evaluated' {
@@ -194,6 +209,14 @@ try
         }
 
         Describe 'xCluster\Set-TargetResource' {
+            BeforeAll {
+                Mock -CommandName Add-Type -MockWith {
+                    return $mockLibImpersonationObject
+                }
+
+                Mock -CommandName New-Object -MockWith $mockNewObjectWindowsIdentity -ParameterFilter $mockNewObjectWindowsIdentity_ParameterFilter -Verifiable
+            }
+
             Context 'When computers domain name cannot be evaluated' {
                 It 'Should throw the correct error message' {
                     $mockDynamicDomainName = $null
@@ -339,6 +362,14 @@ try
         }
 
         Describe 'xCluster\Test-TargetResource' {
+            BeforeAll {
+                Mock -CommandName Add-Type -MockWith {
+                    return $mockLibImpersonationObject
+                }
+
+                Mock -CommandName New-Object -MockWith $mockNewObjectWindowsIdentity -ParameterFilter $mockNewObjectWindowsIdentity_ParameterFilter -Verifiable
+            }
+
             Context 'When computers domain name cannot be evaluated' {
                 It 'Should throw the correct error message' {
                     $mockDynamicDomainName = $null


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xCluster
  - Fixed random problem with tests failing with error "Invalid token for
    impersonation - it cannot be duplicated." (issue #133).

**This Pull Request (PR) fixes the following issues:**
Fixes #133 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/134)
<!-- Reviewable:end -->
