### PR TITLE
xFailOverCluster: Fixed Script Analyzer warnings for Write-Verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - Enabled localization for all strings ([issue #84](https://github.com/PowerShell/xFailOverCluster/issues/84)).
   - Fixed the OutputType data type that was not fully qualified.
   - Minor style changes.
+  - Fixed Script Analyzer warnings for Write-Verbose.
 - Changes to xClusterNetwork
   - Replaced the URL for the parameter Role in README.md. The new URL is a more
     generic description of the possible settings for the Role parameter. The
@@ -31,6 +32,7 @@
   - Fixed typos in parameter descriptions in README.md, comment-based help and schema.mof.
   - Enabled localization for all strings ([issue #85](https://github.com/PowerShell/xFailOverCluster/issues/85)).
   - Minor style changes.
+  - Fixed Script Analyzer warnings for Write-Verbose.
 - Changes to xCluster
   - Resolved Script Analyzer rule warnings by changing Get-WmiObject to
     Get-CimInstance ([issue #49](https://github.com/PowerShell/xFailOverCluster/issues/49)).
@@ -41,6 +43,7 @@
     - Fixed random problem with tests failing with error "Invalid token for
       impersonation - it cannot be duplicated." ([issue #133](https://github.com/PowerShell/xFailOverCluster/issues/133)).
   - Minor style changes.
+  - Fixed Script Analyzer warnings for Write-Verbose.
 - Changes to xWaitForCluster
   - Refactored the unit test for this resource to use stubs and increase coverage
     ([issue #78](https://github.com/PowerShell/xFailOverCluster/issues/78)).

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -34,6 +34,8 @@ function Get-TargetResource
         $DomainAdministratorCredential
     )
 
+    Write-Verbose -Message ($script:localizedData.GetClusterInformation -f $Name)
+
     $computerInformation = Get-CimInstance -ClassName Win32_ComputerSystem
     if (($null -eq $computerInformation) -or ($null -eq $computerInformation.Domain))
     {

--- a/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
+++ b/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
@@ -18,4 +18,5 @@ ConvertFrom-StringData @'
     FailedCreatingCluster = Cluster creation failed. Please verify output of 'Get-Cluster' command.
     UnableToImpersonateUser = Can't logon as user {0}.
     UnableToCloseToken = Can't close impersonation token {0}.
+    GetClusterInformation = Retrieving information for cluster {0}.
 '@

--- a/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
+++ b/DSCResources/MSFT_xClusterDisk/MSFT_xClusterDisk.psm1
@@ -21,6 +21,8 @@ function Get-TargetResource
         $Number
     )
 
+    Write-Verbose -Message ($script:localizedData.GetClusterDiskInformation -f $Number)
+
     if ($null -ne ($diskInstance = Get-CimInstance -ClassName MSCluster_Disk -Namespace 'Root\MSCluster' -Filter "Number = $Number"))
     {
         $diskResource = Get-ClusterResource |
@@ -162,6 +164,8 @@ function Test-TargetResource
         [System.String]
         $Label
     )
+
+    Write-Verbose -Message ($script:localizedData.EvaluatingClusterDiskInformation -f $Number)
 
     $getTargetResourceResult = Get-TargetResource -Number $Number
 

--- a/DSCResources/MSFT_xClusterDisk/en-US/MSFT_xClusterDisk.strings.psd1
+++ b/DSCResources/MSFT_xClusterDisk/en-US/MSFT_xClusterDisk.strings.psd1
@@ -4,4 +4,6 @@ ConvertFrom-StringData @'
     AddDiskToCluster = Add the disk {0} to the cluster.
     SetDiskLabel = Set the disk label for the disk {0} to '{1}'.
     RemoveDiskFromCluster = Remove the disk {0} from the cluster.
+    GetClusterDiskInformation = Retrieving information for cluster disk {0}.
+    EvaluatingClusterDiskInformation = Evaluating state of cluster disk {0}.
 '@

--- a/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
+++ b/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
@@ -28,6 +28,8 @@ function Get-TargetResource
         $AddressMask
     )
 
+    Write-Verbose -Message ($script:localizedData.GetClusterNetworkInformation -f $Name)
+
     $NetworkResource = Get-ClusterNetwork | Where-Object -FilterScript {
         $_.Address -eq $Address -and $_.AddressMask -eq $AddressMask
     }
@@ -197,6 +199,8 @@ function Test-TargetResource
         [System.String]
         $Metric
     )
+
+    Write-Verbose -Message ($script:localizedData.EvaluatingClusterNetworkInformation -f $Name)
 
     $getTargetResourceResult = Get-TargetResource -Address $Address -AddressMask $AddressMask
 

--- a/DSCResources/MSFT_xClusterNetwork/en-US/MSFT_xClusterNetwork.strings.psd1
+++ b/DSCResources/MSFT_xClusterNetwork/en-US/MSFT_xClusterNetwork.strings.psd1
@@ -4,4 +4,6 @@ ConvertFrom-StringData @'
     ChangeNetworkName = Changing the name of the network {0}/{1} to '{2}'.
     ChangeNetworkRole = Changing the role of the network {0}/{1} to '{2}'.
     ChangeNetworkMetric = Changing the metric of the network {0}/{1} to '{2}'.
+    GetClusterNetworkInformation = Retrieving information for cluster network {0}.
+    EvaluatingClusterNetworkInformation = Evaluating state of cluster network {0}.
 '@


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xCluster
  - Fixed Script Analyzer warnings for Write-Verbose.
- Changes to xClusterDisk
  - Fixed Script Analyzer warnings for Write-Verbose.
- Changes to xClusterNetwork
  - Fixed Script Analyzer warnings for Write-Verbose.

**This Pull Request (PR) fixes the following issues:**
n/a

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/137)
<!-- Reviewable:end -->
