### PR TITLE
xClusterQuorum: Fixed the filesharewitness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
     and error ([issue #28](https://github.com/PowerShell/xFailOverCluster/issues/28)).
   - Added -IgnoreNetwork parameter ([issue #143](https://github.com/PowerShell/xFailOverCluster/issues/143)).
 - Changes to xClusterQuorum
-  - server 2016 test failed on nodeandfilesharemajority if you used filesharemajority.
+  - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run failed when Test-TargetResource validated the configuration.
 
 ## 1.8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
     and error ([issue #28](https://github.com/PowerShell/xFailOverCluster/issues/28)).
   - Added -IgnoreNetwork parameter ([issue #143](https://github.com/PowerShell/xFailOverCluster/issues/143)).
 - Changes to xClusterQuorum
-  - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run failed when Test-TargetResource validated the configuration.
+  - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run
+    failed when Test-TargetResource validated the configuration.
 
 ## 1.8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   - Get-TargetResource now correctly returns the IP address instead of throwing
     and error ([issue #28](https://github.com/PowerShell/xFailOverCluster/issues/28)).
   - Added -IgnoreNetwork parameter ([issue #143](https://github.com/PowerShell/xFailOverCluster/issues/143)).
+- Changes to xClusterQuorum
+  - server 2016 test failed on nodeandfilesharemajority if you used filesharemajority.
 
 ## 1.8.0.0
 

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
             {
                 $clusterQuorumType = 'NodeAndDiskMajority'
             }
-            elseif ($getClusterQuorumResult.QuorumResource.ResourceType.DisplayName -eq 'File Share Witness')
+            elseif ($getClusterQuorumResult.QuorumResource.ResourceType.DisplayName -eq 'File Share Witness' -or $getClusterQuorumResult.QuorumResource.ResourceType.DisplayName -eq 'File Share Quorum Witness')
             {
                 $clusterQuorumType = 'NodeAndFileShareMajority'
             }
@@ -78,7 +78,7 @@ function Get-TargetResource
         }
     }
 
-    if ($clusterQuorumType -eq 'NodeAndFileShareMajority')
+    if ($clusterQuorumType -eq 'NodeAndFileShareMajority' -or $clusterQuorumType -eq 'FileShareWitness')
     {
         $clusterQuorumResource = $getClusterQuorumResult.QuorumResource |
             Get-ClusterParameter -Name SharePath |

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
@@ -78,7 +78,7 @@ function Get-TargetResource
         }
     }
 
-    if ($clusterQuorumType -eq 'NodeAndFileShareMajority' -or $clusterQuorumType -eq 'FileShareWitness')
+    if ($clusterQuorumType -eq 'NodeAndFileShareMajority')
     {
         $clusterQuorumResource = $getClusterQuorumResult.QuorumResource |
             Get-ClusterParameter -Name SharePath |

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
@@ -1,5 +1,5 @@
 Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
--ChildPath 'CommonResourceHelper.psm1')
+        -ChildPath 'CommonResourceHelper.psm1')
 
 $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xClusterQuorum'
 
@@ -39,7 +39,7 @@ function Get-TargetResource
             {
                 $clusterQuorumType = 'NodeAndDiskMajority'
             }
-            elseif ($getClusterQuorumResult.QuorumResource.ResourceType.DisplayName -eq 'File Share Witness' -or $getClusterQuorumResult.QuorumResource.ResourceType.DisplayName -eq 'File Share Quorum Witness')
+            elseif ($getClusterQuorumResult.QuorumResource.ResourceType.DisplayName -eq 'File Share Quorum Witness')
             {
                 $clusterQuorumType = 'NodeAndFileShareMajority'
             }

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Configures quorum in a cluster.
 >Note: if you want to use FileShareWitness, use the option NodeAndFileShareMajority.
 >Note: if you want to use DiskWitness, use the option NodeAndDiskMajority.
 >Note: if you want to use NoWitness, use the option NodeMajority.
+
 #### Examples for xClusterQuorum
 
 * [Set quorum to node majority](/Examples/Resources/xClusterQuorum/1-SetQuorumToNodeMajority.ps1)

--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Configures quorum in a cluster.
   to use as witness. This parameter is optional if the quorum type is set to
   NodeMajority.
 
->Note: if you want to use FileShareWitness, use NodeAndFileShareMajority.
+>Note: if you want to use FileShareWitness, use the option NodeAndFileShareMajority.
+>Note: if you want to use DiskWitness, use the option NodeAndDiskMajority.
+>Note: if you want to use NoWitness, use the option NodeMajority.
 #### Examples for xClusterQuorum
 
 * [Set quorum to node majority](/Examples/Resources/xClusterQuorum/1-SetQuorumToNodeMajority.ps1)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ cluster.
 
 ### xClusterQuorum
 
-Configures quorum in a cluster.
+Configures quorum in a cluster. For information on how to choose the correct
+quorum type, please see the article
+[Understanding Quorum Configurations in a Failover Cluster](https://technet.microsoft.com/en-us/library/cc731739(v=ws.11).aspx).
 
 #### Requirements for xClusterQuorum
 
@@ -188,10 +190,6 @@ Configures quorum in a cluster.
 * **`[String]` Resource** _(Write)_: The name of the disk or file share resource
   to use as witness. This parameter is optional if the quorum type is set to
   NodeMajority.
-
->Note: if you want to use FileShareWitness, use the option NodeAndFileShareMajority.
->Note: if you want to use DiskWitness, use the option NodeAndDiskMajority.
->Note: if you want to use NoWitness, use the option NodeMajority.
 
 #### Examples for xClusterQuorum
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Configures quorum in a cluster.
   to use as witness. This parameter is optional if the quorum type is set to
   NodeMajority.
 
+>Note: if you want to use FileShareWitness, use NodeAndFileShareMajority.
 #### Examples for xClusterQuorum
 
 * [Set quorum to node majority](/Examples/Resources/xClusterQuorum/1-SetQuorumToNodeMajority.ps1)

--- a/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
@@ -43,6 +43,8 @@ try
         $mockQuorumType_DiskOnly = 'DiskOnly'
         $mockQuorumType_Unknown = 'Unknown'
 
+        $mockQuorumTypeDisplayName = 'File Share Quorum Witness'
+
         $mockQuorumResourceName = 'Witness'
         $mockQuorumFileShareWitnessPath = '\\FILE01\CLUSTER01'
 
@@ -59,7 +61,7 @@ try
                 }
             }
 
-            switch ($mockDynamicExcpectedQuorumType)
+            switch ($mockDynamicExpectedQuorumType)
             {
                 $mockQuorumType_NodeMajority
                 {
@@ -73,7 +75,7 @@ try
 
                 $mockQuorumType_NodeAndFileShareMajority
                 {
-                    $getClusterQuorumReturnValue.QuorumResource.ResourceType.DisplayName = 'File Share Witness'
+                    $getClusterQuorumReturnValue.QuorumResource.ResourceType.DisplayName = $mockDynamicQuorumTypeDisplayName
                 }
 
                 $mockQuorumType_Unknown
@@ -88,7 +90,7 @@ try
         $mockGetClusterParameter = {
             @(
                 [PSCustomObject] @{
-                    ClusterObject = 'File Share Witness'
+                    ClusterObject = $mockDynamicQuorumTypeDisplayName
                     Name          = 'SharePath'
                     IsReadOnly    = 'False'
                     ParameterType = 'String'
@@ -121,7 +123,7 @@ try
             $wrongParameters = $false
 
             # Evaluate if the Set-ClusterQuorum is called with the correct parameters.
-            switch ($mockDynamicSetClusterQuorum_ExcpectedQuorumType)
+            switch ($mockDynamicSetClusterQuorum_ExpectedQuorumType)
             {
                 $mockQuorumType_NodeMajority
                 {
@@ -210,7 +212,7 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeMajority
                         }
 
                         It 'Should return the same values as passed as parameters' {
@@ -247,7 +249,7 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
                         }
 
                         It 'Should return the same values as passed as parameters' {
@@ -284,7 +286,8 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+                            $mockDynamicQuorumTypeDisplayName = $mockQuorumTypeDisplayName
                         }
 
                         It 'Should return the same values as passed as parameters' {
@@ -331,7 +334,7 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_Unknown
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_Unknown
                         }
 
                         It 'Should throw the correct error message' {
@@ -374,7 +377,7 @@ try
                             $mockDynamicQuorumType = $mockQuorumType_Majority
                             $mockDynamicQuorumResourceName = $mockQuorumResourceName
 
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
                         }
 
                         It 'Should return the value $false' {
@@ -406,7 +409,7 @@ try
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
 
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeMajority
                         }
 
                         It 'Should return the value $false' {
@@ -431,7 +434,7 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
                         }
 
                         It 'Should return the value $false' {
@@ -456,7 +459,8 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+                            $mockDynamicQuorumTypeDisplayName = $mockQuorumTypeDisplayName
                         }
 
                         It 'Should return the value $false' {
@@ -502,7 +506,7 @@ try
                             $mockDynamicQuorumType = $mockQuorumType_Majority
                             $mockTestParameters['Resource'] = $null
 
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeMajority
                         }
 
                         It 'Should return the value $true' {
@@ -526,7 +530,7 @@ try
 
                     $mockTestParameters['Type'] = $mockQuorumType_NodeMajority
 
-                    $mockDynamicSetClusterQuorum_ExcpectedQuorumType = $mockQuorumType_NodeMajority
+                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -547,7 +551,7 @@ try
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
                     $mockDynamicQuorumResourceName = $mockQuorumResourceName
-                    $mockDynamicSetClusterQuorum_ExcpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
+                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -568,7 +572,7 @@ try
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
                     $mockDynamicQuorumResourceName = $mockQuorumResourceName
-                    $mockDynamicSetClusterQuorum_ExcpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -589,7 +593,7 @@ try
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
                     $mockDynamicQuorumResourceName = $mockQuorumResourceName
-                    $mockDynamicSetClusterQuorum_ExcpectedQuorumType = $mockQuorumType_DiskOnly
+                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_DiskOnly
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xClusterQuorum
  - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run
    failed when Test-TargetResource validated the configuration.

**This Pull Request (PR) fixes the following issues:**
Fixes #35

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible

Previous PR-> https://github.com/PowerShell/xFailOverCluster/pull/141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/144)
<!-- Reviewable:end -->
