### PR TITLE
xFailOverCluster: Update Pester syntax to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Changes to xFailoverCluster
-  - Updated Pester command flags to v4
+  - Update Pester syntax to v4
 - Changes to xClusterNetwork
   - Updated readme to describe process for adding and removing additional networks on clusters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Changes to xFailoverCluster
+  - Updated Pester command flags to v4
 - Changes to xClusterNetwork
   - Updated readme to describe process for adding and removing additional networks on clusters
 

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'CommonResourceHelper Unit Tests' {
             }
 
             $mockImportLocalizedData = {
-                $BaseDirectory | Should Be $mockExpectedLanguagePath
+                $BaseDirectory | Should -Be $mockExpectedLanguagePath
             }
 
             BeforeEach {
@@ -32,7 +32,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                         return 'sv-SE'
                     } -Verifiable
 
-                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should Not Throw
+                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should -Not -Throw
 
                     Assert-MockCalled -CommandName Join-Path -Exactly -Times 2 -Scope It
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
@@ -47,7 +47,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                         return $ChildPath
                     } -Verifiable
 
-                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should Not Throw
+                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should -Not -Throw
 
                     Assert-MockCalled -CommandName Join-Path -Exactly -Times 3 -Scope It
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
@@ -63,7 +63,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                             return 'sv-SE'
                         } -Verifiable
 
-                        { Get-LocalizedData -ResourceName 'DummyResource' -ScriptRoot '.' } | Should Not Throw
+                        { Get-LocalizedData -ResourceName 'DummyResource' -ScriptRoot '.' } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName Join-Path -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
@@ -78,7 +78,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                             return $ChildPath
                         } -Verifiable
 
-                        { Get-LocalizedData -ResourceName 'DummyResource' -ScriptRoot '.' } | Should Not Throw
+                        { Get-LocalizedData -ResourceName 'DummyResource' -ScriptRoot '.' } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName Join-Path -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It
@@ -96,7 +96,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 $mockTestPathReturnValue = $true
 
                 It 'Should call Import-LocalizedData with en-US language' {
-                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should Not Throw
+                    { Get-LocalizedData -ResourceName 'DummyResource' } | Should -Not -Throw
                 }
             }
 
@@ -108,7 +108,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 It 'Should throw the correct error' {
                     $mockErrorMessage = 'Mocked error'
 
-                    { New-InvalidResultException -Message $mockErrorMessage } | Should Throw $mockErrorMessage
+                    { New-InvalidResultException -Message $mockErrorMessage } | Should -Throw $mockErrorMessage
                 }
             }
 
@@ -120,7 +120,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
+                    { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should -Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -132,7 +132,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 It 'Should throw the correct error' {
                     $mockErrorMessage = 'Mocked error'
 
-                    { New-ObjectNotFoundException -Message $mockErrorMessage } | Should Throw $mockErrorMessage
+                    { New-ObjectNotFoundException -Message $mockErrorMessage } | Should -Throw $mockErrorMessage
                 }
             }
 
@@ -144,7 +144,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
+                    { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should -Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -156,7 +156,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 It 'Should throw the correct error' {
                     $mockErrorMessage = 'Mocked error'
 
-                    { New-InvalidOperationException -Message $mockErrorMessage } | Should Throw $mockErrorMessage
+                    { New-InvalidOperationException -Message $mockErrorMessage } | Should -Throw $mockErrorMessage
                 }
             }
 
@@ -168,7 +168,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.InvalidOperationException: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
+                    { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should -Throw ('System.InvalidOperationException: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -181,7 +181,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     $mockErrorMessage = 'Mocked error'
                     $mockArgumentName = 'MockArgument'
 
-                    { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should Throw ('Parameter name: {0}' -f $mockArgumentName)
+                    { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should -Throw ('Parameter name: {0}' -f $mockArgumentName)
                 }
             }
 

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -165,7 +165,7 @@ try
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
-                    { Get-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
+                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -178,7 +178,7 @@ try
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     $mockCorrectErrorRecord = Get-ObjectNotFoundException -Message ($script:localizedData.ClusterNameNotFound -f $mockClusterName)
-                    { Get-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
+                    { Get-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -195,13 +195,13 @@ try
 
                 It 'Returns a [System.Collection.Hashtable] type' {
                     $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
-                    $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                    $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                 }
 
                 It 'Returns current configuration' {
                     $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
-                    $getTargetResourceResult.Name             | Should Be $mockDefaultParameters.Name
-                    $getTargetResourceResult.StaticIPAddress  | Should Be $mockDefaultParameters.StaticIPAddress
+                    $getTargetResourceResult.Name             | Should -Be $mockDefaultParameters.Name
+                    $getTargetResourceResult.StaticIPAddress  | Should -Be $mockDefaultParameters.StaticIPAddress
                 }
 
                 Assert-VerifiableMocks
@@ -225,7 +225,7 @@ try
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
-                    { Set-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
+                    { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -249,7 +249,7 @@ try
                             # This is used to evaluate that cluster do exists after New-Cluster cmdlet has been run.
                             Mock -CommandName Get-Cluster -MockWith $mockGetCluster
 
-                            { Set-TargetResource @mockDefaultParameters } | Should Not Throw
+                            { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 
                             Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -267,7 +267,7 @@ try
                             # This is used to evaluate that cluster do exists after New-Cluster cmdlet has been run.
                             Mock -CommandName Get-Cluster -MockWith $mockGetCluster
 
-                            { Set-TargetResource @mockDefaultParameters } | Should Not Throw
+                            { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 
                             Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -281,7 +281,7 @@ try
                         Mock -CommandName Get-Cluster
 
                         $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.FailedCreatingCluster
-                        { Set-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
+                        { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -294,7 +294,7 @@ try
                         Mock -CommandName Get-ClusterNode
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
 
-                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -312,7 +312,7 @@ try
                     It 'Should call both Remove-ClusterNode and Add-ClusterNode cmdlet' {
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
 
-                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 1 -Scope It
@@ -349,7 +349,7 @@ try
                     It 'Should not call any of the cluster cmdlets' -Skip {
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
 
-                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
@@ -378,7 +378,7 @@ try
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter -Verifiable
 
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
-                    { Test-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
+                    { Test-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -395,7 +395,7 @@ try
                         Mock -CommandName Get-Cluster -Verifiable
 
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -408,7 +408,7 @@ try
                         } -Verifiable
 
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -421,7 +421,7 @@ try
 
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
 
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -438,7 +438,7 @@ try
                     It 'Should return $false' {
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
 
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     Assert-VerifiableMocks
@@ -460,7 +460,7 @@ try
                 Context 'When the node already exist' {
                     It 'Should return $true' {
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
 
                     Assert-VerifiableMocks
@@ -479,7 +479,7 @@ try
                     }
 
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message ($script:localizedData.UnableToImpersonateUser -f $mockAdministratorCredential.GetNetworkCredential().UserName)
-                    { Set-ImpersonateAs -Credential $mockAdministratorCredential } | Should Throw $mockCorrectErrorRecord
+                    { Set-ImpersonateAs -Credential $mockAdministratorCredential } | Should -Throw $mockCorrectErrorRecord
                 }
             }
         }
@@ -494,7 +494,7 @@ try
                     $mockToken = [System.IntPtr]::New(12345)
 
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message ($script:localizedData.UnableToCloseToken -f $mockToken.ToString())
-                    { Close-UserToken -Token $mockToken } | Should Throw $mockCorrectErrorRecord
+                    { Close-UserToken -Token $mockToken } | Should -Throw $mockCorrectErrorRecord
                 }
             }
         }

--- a/Tests/Unit/MSFT_xClusterDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterDisk.Tests.ps1
@@ -159,18 +159,18 @@ try
 
                     It 'Should return the correct type' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                        $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                     }
 
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Number | Should Be $mockTestParameters.Number
+                        $getTargetResourceResult.Number | Should -Be $mockTestParameters.Number
                     }
 
                     It 'Should return the disk as absent' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Ensure | Should Be 'Absent'
-                        $getTargetResourceResult.Label  | Should BeNullOrEmpty
+                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                        $getTargetResourceResult.Label  | Should -BeNullOrEmpty
                     }
                 }
 
@@ -183,13 +183,13 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Number | Should Be $mockTestParameters.Number
+                        $getTargetResourceResult.Number | Should -Be $mockTestParameters.Number
                     }
 
                     It 'Should return the disk as present' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Ensure | Should Be 'Present'
-                        $getTargetResourceResult.Label | Should Be $mockDiskLabel
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Label | Should -Be $mockDiskLabel
                     }
                 }
 
@@ -202,18 +202,18 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Number | Should Be $mockTestParameters.Number
+                        $getTargetResourceResult.Number | Should -Be $mockTestParameters.Number
                     }
 
                     It 'Should return the correct value for property Ensure' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Ensure | Should Be 'Present'
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
                     }
 
                     It 'Should return the correct value for property Label' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Label | Should Not Be $mockDisk_WrongLabel
-                        $getTargetResourceResult.Label | Should Be $mockDiskLabel
+                        $getTargetResourceResult.Label | Should -Not -Be $mockDisk_WrongLabel
+                        $getTargetResourceResult.Label | Should -Be $mockDiskLabel
                     }
                 }
             }
@@ -228,14 +228,14 @@ try
 
                     It 'Should return the correct type' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                        $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                     }
 
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Number | Should Be $mockTestParameters.Number
-                        $getTargetResourceResult.Ensure | Should Be 'Present'
-                        $getTargetResourceResult.Label  | Should Be $mockDiskLabel
+                        $getTargetResourceResult.Number | Should -Be $mockTestParameters.Number
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Label  | Should -Be $mockDiskLabel
                     }
                 }
 
@@ -248,9 +248,9 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Number | Should Be $mockTestParameters.Number
-                        $getTargetResourceResult.Ensure | Should Be 'Absent'
-                        $getTargetResourceResult.Label  | Should BeNullOrEmpty
+                        $getTargetResourceResult.Number | Should -Be $mockTestParameters.Number
+                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                        $getTargetResourceResult.Label  | Should -BeNullOrEmpty
                     }
                 }
             }
@@ -267,21 +267,21 @@ try
                 Context 'When Ensure is set to ''Present'' but the disk is not present' {
                     It 'Should return $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameter_ShouldBePresentButDiskDoesNotExist
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
                 Context 'When Ensure is set to ''Absent'' and the disk is present' {
                     It 'Should return $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameter_ShouldBeAbsentButDiskExist
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
                 Context 'When Ensure is set to ''Present'' and the disk is present but has the wrong label' {
                     It 'Should return $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameter_ShouldBePresentAndDiskExistButWrongLabel
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
             }
@@ -290,14 +290,14 @@ try
                 Context 'When Ensure is set to ''Present'' and the disk is present' {
                     It 'Should return $true' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameter_ShouldBePresentAndDiskExist
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
                 }
 
                 Context 'When Ensure is set to ''Absent'' and the disk is not present' {
                     It 'Should return $true' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameter_ShouldBeAbsentAndDiskDoesNotExist
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
                 }
             }
@@ -332,7 +332,7 @@ try
                     }
 
                     It 'Should add the disk to the cluster' {
-                        { Set-TargetResource @mockTestParameter_ShouldBePresentButDiskDoesNotExist } | Should Not Throw
+                        { Set-TargetResource @mockTestParameter_ShouldBePresentButDiskDoesNotExist } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName Add-ClusterDisk -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterResource -Exactly -Times 0 -Scope It
@@ -351,7 +351,7 @@ try
                     }
 
                     It 'Should remove the disk from the cluster' {
-                        { Set-TargetResource @mockTestParameter_ShouldBeAbsentButDiskExist } | Should Not Throw
+                        { Set-TargetResource @mockTestParameter_ShouldBeAbsentButDiskExist } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName Add-ClusterDisk -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterResource -Exactly -Times 1 -Scope It
@@ -372,7 +372,7 @@ try
                     }
 
                     It 'Should not call any cluster cmdlets' {
-                        { Set-TargetResource @mockTestParameter_ShouldBePresentAndDiskExist } | Should Not Throw
+                        { Set-TargetResource @mockTestParameter_ShouldBePresentAndDiskExist } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName Add-ClusterDisk -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
@@ -392,7 +392,7 @@ try
                     }
 
                     It 'Should not call any cluster cmdlets' {
-                        { Set-TargetResource @mockTestParameter_ShouldBeAbsentAndDiskDoesNotExist } | Should Not Throw
+                        { Set-TargetResource @mockTestParameter_ShouldBeAbsentAndDiskDoesNotExist } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName Add-ClusterDisk -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterResource -Exactly -Times 0 -Scope It

--- a/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
@@ -90,20 +90,20 @@ try
 
                 It 'Should return the correct type' {
                     $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                    $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                    $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                 }
 
                 It 'Should return the same values passed as parameters' {
                     $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                    $getTargetResourceResult.Address      | Should Be $mockTestParameters.Address
-                    $getTargetResourceResult.AddressMask  | Should Be $mockTestParameters.AddressMask
+                    $getTargetResourceResult.Address      | Should -Be $mockTestParameters.Address
+                    $getTargetResourceResult.AddressMask  | Should -Be $mockTestParameters.AddressMask
                 }
 
                 It 'Should not return the the correct values for the cluster network' {
                     $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                    $getTargetResourceResult.Name         | Should Not Be $mockAbsentClusterNetworkName
-                    $getTargetResourceResult.Role         | Should Not Be $mockAbsentClusterNetworkRole
-                    $getTargetResourceResult.Metric       | Should Not Be $mockAbsentClusterNetworkMetric
+                    $getTargetResourceResult.Name         | Should -Not -Be $mockAbsentClusterNetworkName
+                    $getTargetResourceResult.Role         | Should -Not -Be $mockAbsentClusterNetworkRole
+                    $getTargetResourceResult.Metric       | Should -Not -Be $mockAbsentClusterNetworkMetric
 
                     Assert-MockCalled -CommandName Get-ClusterNetwork -Exactly -Times 1 -Scope It
                 }
@@ -119,20 +119,20 @@ try
 
                 It 'Should return the correct type' {
                     $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                    $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                    $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                 }
 
                 It 'Should return the same values passed as parameters' {
                     $Result = Get-TargetResource @mockTestParameters
-                    $Result.Address      | Should Be $mockTestParameters.Address
-                    $Result.AddressMask  | Should Be $mockTestParameters.AddressMask
+                    $Result.Address      | Should -Be $mockTestParameters.Address
+                    $Result.AddressMask  | Should -Be $mockTestParameters.AddressMask
                 }
 
                 It 'Should return the the correct values for the cluster network' {
                     $Result = Get-TargetResource @mockTestParameters
-                    $Result.Name         | Should Be $mockPresentClusterNetworkName
-                    $Result.Role         | Should Be $mockPresentClusterNetworkRole
-                    $Result.Metric       | Should Be $mockPresentClusterNetworkMetric
+                    $Result.Name         | Should -Be $mockPresentClusterNetworkName
+                    $Result.Role         | Should -Be $mockPresentClusterNetworkRole
+                    $Result.Metric       | Should -Be $mockPresentClusterNetworkMetric
 
                     Assert-MockCalled -CommandName Get-ClusterNetwork -Exactly -Times 1 -Scope It
                 }
@@ -149,7 +149,7 @@ try
 
                     It 'Should return result as $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
@@ -161,7 +161,7 @@ try
 
                     It 'Should return result as $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
@@ -173,7 +173,7 @@ try
 
                     It 'Should return result as $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
@@ -185,7 +185,7 @@ try
 
                     It 'Should return result as $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
             }
@@ -197,7 +197,7 @@ try
 
                 It 'Should return result as $true' {
                     $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
             }
         }
@@ -216,8 +216,8 @@ try
                     }
 
                     It 'Should call Update method correct number of times' {
-                        { Set-TargetResource @mockTestParameters } | Should Not Throw
-                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should BeExactly 3
+                        { Set-TargetResource @mockTestParameters } | Should -Not -Throw
+                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should -BeExactly 3
                     }
                 }
 
@@ -228,8 +228,8 @@ try
                     }
 
                     It 'Should call Update method correct number of times' {
-                        { Set-TargetResource @mockTestParameters } | Should Not Throw
-                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should BeExactly 1
+                        { Set-TargetResource @mockTestParameters } | Should -Not -Throw
+                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should -BeExactly 1
                     }
                 }
 
@@ -240,8 +240,8 @@ try
                     }
 
                     It 'Should call Update method correct number of times' {
-                        { Set-TargetResource @mockTestParameters } | Should Not Throw
-                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should BeExactly 1
+                        { Set-TargetResource @mockTestParameters } | Should -Not -Throw
+                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should -BeExactly 1
                     }
                 }
 
@@ -252,8 +252,8 @@ try
                     }
 
                     It 'Should call Update method correct number of times' {
-                        { Set-TargetResource @mockTestParameters } | Should Not Throw
-                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should BeExactly 1
+                        { Set-TargetResource @mockTestParameters } | Should -Not -Throw
+                        $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should -BeExactly 1
                     }
                 }
             }
@@ -268,8 +268,8 @@ try
                 }
 
                 It 'Should call Update method correct number of times' {
-                    { Set-TargetResource @mockTestParameters } | Should Not Throw
-                    $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should BeExactly 0
+                    { Set-TargetResource @mockTestParameters } | Should -Not -Throw
+                    $script:mockNumerOfTimesMockedMethodUpdateWasCalled | Should -BeExactly 0
                 }
             }
         }

--- a/Tests/Unit/MSFT_xClusterPreferredOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterPreferredOwner.Tests.ps1
@@ -146,50 +146,50 @@ try
                 Context 'When Ensure is set to ''Present'' but the preferred owner is not a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the correct type' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Present_WrongPreferredOwnerNodes
-                        $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                        $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                     }
 
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Present_WrongPreferredOwnerNodes
-                        $getTargetResourceResult.ClusterGroup | Should Be $mockTestParameters_Present_WrongPreferredOwnerNodes.ClusterGroup
-                        $getTargetResourceResult.ClusterName  | Should Be $mockTestParameters_Present_WrongPreferredOwnerNodes.ClusterName
-                        $getTargetResourceResult.Ensure       | Should Be $mockTestParameters_Present_WrongPreferredOwnerNodes.Ensure
+                        $getTargetResourceResult.ClusterGroup | Should -Be $mockTestParameters_Present_WrongPreferredOwnerNodes.ClusterGroup
+                        $getTargetResourceResult.ClusterName  | Should -Be $mockTestParameters_Present_WrongPreferredOwnerNodes.ClusterName
+                        $getTargetResourceResult.Ensure       | Should -Be $mockTestParameters_Present_WrongPreferredOwnerNodes.Ensure
                     }
 
                     It 'Should return the wrong preferred owner nodes and the right cluster resources' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Present_WrongPreferredOwnerNodes
-                        $getTargetResourceResult.Nodes            | Should Not Be $mockTestParameters_Present_WrongPreferredOwnerNodes.Nodes
-                        $getTargetResourceResult.ClusterResources | Should Be $mockTestParameters_Present_WrongPreferredOwnerNodes.ClusterResources
+                        $getTargetResourceResult.Nodes            | Should -Not -Be $mockTestParameters_Present_WrongPreferredOwnerNodes.Nodes
+                        $getTargetResourceResult.ClusterResources | Should -Be $mockTestParameters_Present_WrongPreferredOwnerNodes.ClusterResources
                     }
                 }
 
                 Context 'When Ensure is set to ''Present'' but the preferred owner is a possible owner of the cluster nodes but the cluster resources is missing' {
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Present_WrongClusterResources
-                        $getTargetResourceResult.ClusterGroup | Should Be $mockTestParameters_Present_WrongClusterResources.ClusterGroup
-                        $getTargetResourceResult.ClusterName  | Should Be $mockTestParameters_Present_WrongClusterResources.ClusterName
-                        $getTargetResourceResult.Ensure       | Should Be $mockTestParameters_Present_WrongClusterResources.Ensure
+                        $getTargetResourceResult.ClusterGroup | Should -Be $mockTestParameters_Present_WrongClusterResources.ClusterGroup
+                        $getTargetResourceResult.ClusterName  | Should -Be $mockTestParameters_Present_WrongClusterResources.ClusterName
+                        $getTargetResourceResult.Ensure       | Should -Be $mockTestParameters_Present_WrongClusterResources.Ensure
                     }
 
                     It 'Should return the correct preferred owner nodes and the wrong cluster resources' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Present_WrongClusterResources
-                        $getTargetResourceResult.Nodes            | Should Be $mockAllPreferredOwnerNodes
-                        $getTargetResourceResult.ClusterResources | Should Be $mockTestParameters_Present_WrongClusterResources.ClusterResources
+                        $getTargetResourceResult.Nodes            | Should -Be $mockAllPreferredOwnerNodes
+                        $getTargetResourceResult.ClusterResources | Should -Be $mockTestParameters_Present_WrongClusterResources.ClusterResources
                     }
                 }
 
                 Context 'When Ensure is set to ''Absent'' and the preferred owner is still a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Absent_ButPreferredOwnersExist
-                        $getTargetResourceResult.ClusterGroup | Should Be $mockTestParameters_Absent_ButPreferredOwnersExist.ClusterGroup
-                        $getTargetResourceResult.ClusterName  | Should Be $mockTestParameters_Absent_ButPreferredOwnersExist.ClusterName
-                        $getTargetResourceResult.Ensure       | Should Be $mockTestParameters_Absent_ButPreferredOwnersExist.Ensure
+                        $getTargetResourceResult.ClusterGroup | Should -Be $mockTestParameters_Absent_ButPreferredOwnersExist.ClusterGroup
+                        $getTargetResourceResult.ClusterName  | Should -Be $mockTestParameters_Absent_ButPreferredOwnersExist.ClusterName
+                        $getTargetResourceResult.Ensure       | Should -Be $mockTestParameters_Absent_ButPreferredOwnersExist.Ensure
                     }
 
                     It 'Should return the correct preferred owner nodes and the wrong cluster resources' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Absent_ButPreferredOwnersExist
-                        $getTargetResourceResult.Nodes            | Should Be $mockAllPreferredOwnerNodes
-                        $getTargetResourceResult.ClusterResources | Should Be $mockTestParameters_Absent_ButPreferredOwnersExist.ClusterResources
+                        $getTargetResourceResult.Nodes            | Should -Be $mockAllPreferredOwnerNodes
+                        $getTargetResourceResult.ClusterResources | Should -Be $mockTestParameters_Absent_ButPreferredOwnersExist.ClusterResources
                     }
                 }
             }
@@ -198,30 +198,30 @@ try
                 Context 'When Ensure is set to ''Present'' and the preferred owner is a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Present_DesiredPreferredOwners
-                        $getTargetResourceResult.ClusterGroup | Should Be $mockTestParameters_Present_DesiredPreferredOwners.ClusterGroup
-                        $getTargetResourceResult.ClusterName  | Should Be $mockTestParameters_Present_DesiredPreferredOwners.ClusterName
-                        $getTargetResourceResult.Ensure       | Should Be $mockTestParameters_Present_DesiredPreferredOwners.Ensure
+                        $getTargetResourceResult.ClusterGroup | Should -Be $mockTestParameters_Present_DesiredPreferredOwners.ClusterGroup
+                        $getTargetResourceResult.ClusterName  | Should -Be $mockTestParameters_Present_DesiredPreferredOwners.ClusterName
+                        $getTargetResourceResult.Ensure       | Should -Be $mockTestParameters_Present_DesiredPreferredOwners.Ensure
                     }
 
                     It 'Should return the right preferred owner nodes and the right cluster resources' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Present_DesiredPreferredOwners
-                        $getTargetResourceResult.Nodes            | Should Be $mockAllPreferredOwnerNodes
-                        $getTargetResourceResult.ClusterResources | Should Be $mockTestParameters_Present_DesiredPreferredOwners.ClusterResources
+                        $getTargetResourceResult.Nodes            | Should -Be $mockAllPreferredOwnerNodes
+                        $getTargetResourceResult.ClusterResources | Should -Be $mockTestParameters_Present_DesiredPreferredOwners.ClusterResources
                     }
                 }
 
                 Context 'When Ensure is set to ''Absent'' and the preferred owner is not a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Absent_AndPreferredOwnersDoesNotExist
-                        $getTargetResourceResult.ClusterGroup | Should Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.ClusterGroup
-                        $getTargetResourceResult.ClusterName  | Should Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.ClusterName
-                        $getTargetResourceResult.Ensure       | Should Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.Ensure
+                        $getTargetResourceResult.ClusterGroup | Should -Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.ClusterGroup
+                        $getTargetResourceResult.ClusterName  | Should -Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.ClusterName
+                        $getTargetResourceResult.Ensure       | Should -Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.Ensure
                     }
 
                     It 'Should return the correct preferred owner nodes and the wrong cluster resources' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters_Absent_AndPreferredOwnersDoesNotExist
-                        $getTargetResourceResult.Nodes            | Should Not Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.Nodes
-                        $getTargetResourceResult.ClusterResources | Should Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.ClusterResources
+                        $getTargetResourceResult.Nodes            | Should -Not -Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.Nodes
+                        $getTargetResourceResult.ClusterResources | Should -Be $mockTestParameters_Absent_AndPreferredOwnersDoesNotExist.ClusterResources
                     }
                 }
             }
@@ -239,7 +239,7 @@ try
                 Context 'When Ensure is set to ''Present'' but the preferred owner is not a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the result as $false ' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters_Present_WrongPreferredOwnerNodes
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
@@ -247,21 +247,21 @@ try
                 Context 'When Ensure is set to ''Present'' but the preferred owner is a possible owner of the cluster nodes but the cluster resources is missing' {
                     It 'Should return the result as $false ' -Skip {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters_Present_WrongClusterResources
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
                 Context 'When Ensure is set to ''Absent'' and the preferred owner is still a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the result as $false ' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters_Absent_ButPreferredOwnersExist
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
                 Context 'When Ensure is set to ''Present'' and the preferred owners is a possible owners of the cluster nodes and the cluster resources, but there are one additional preferred owner on the nodes that should not be present' {
                     It 'Should return the result as $false ' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters_Present_DesiredPreferredOwners
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
             }
@@ -270,14 +270,14 @@ try
                 Context 'When Ensure is set to ''Present'' and the preferred owner is a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the result as $true ' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters_Present_AllPreferredOwners
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
                 }
 
                 Context 'When Ensure is set to ''Absent'' and the preferred owner is not a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should return the result as $true ' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters_Absent_AndPreferredOwnersDoesNotExist
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
                 }
             }
@@ -296,7 +296,7 @@ try
             Context 'When the system is not in the desired state' {
                 Context 'When Ensure is set to ''Present'' but the preferred owner is not a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should set the preferred owners' {
-                        { Set-TargetResource @mockTestParameters_Present_WrongPreferredOwnerNodes } | Should Not Throw
+                        { Set-TargetResource @mockTestParameters_Present_WrongPreferredOwnerNodes } | Should -Not -Throw
 
                         # Called three times, one times for each node (2 nodes), and one time for each cluster resource (1 resource).
                         Assert-MockCalled -CommandName 'Set-ClusterOwnerNode' -Exactly -Times 3 -Scope It
@@ -308,7 +308,7 @@ try
 
                 Context 'When Ensure is set to ''Present'' but the preferred owner is a possible owner of the cluster nodes but the cluster resources is missing' {
                     It 'Should set the preferred owners' {
-                        { Set-TargetResource @mockTestParameters_Present_WrongClusterResources } | Should Not Throw
+                        { Set-TargetResource @mockTestParameters_Present_WrongClusterResources } | Should -Not -Throw
 
                         # Called two times, one times for each node (2 nodes), and not called for cluster resource because cluster resource is missing.
                         Assert-MockCalled -CommandName 'Set-ClusterOwnerNode' -Exactly -Times 2 -Scope It
@@ -320,7 +320,7 @@ try
 
                 Context 'When Ensure is set to ''Absent'' and the preferred owner is still a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should remove the preferred owners, leaving one preferred owner' {
-                        { Set-TargetResource @mockTestParameters_Absent_ButPreferredOwnersExist } | Should Not Throw
+                        { Set-TargetResource @mockTestParameters_Absent_ButPreferredOwnersExist } | Should -Not -Throw
 
                         # Called two times, one times for each node (2 nodes), and one time for each cluster resource (1 resource).
                         Assert-MockCalled -CommandName 'Set-ClusterOwnerNode' -Exactly -Times 3 -Scope It
@@ -335,7 +335,7 @@ try
                 # This tests wrongly calls Set-ClusterOwnerNode and Move-ClusterGroup. See issue #97.
                 Context 'When Ensure is set to ''Present'' and the preferred owner is a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should do nothing' {
-                        { Set-TargetResource @mockTestParameters_Present_AllPreferredOwners } | Should Not Throw
+                        { Set-TargetResource @mockTestParameters_Present_AllPreferredOwners } | Should -Not -Throw
 
                         # Called two times, one times for each node (2 nodes), and one time for each cluster resource (1 resource).
                         Assert-MockCalled -CommandName 'Set-ClusterOwnerNode' -Exactly -Times 3 -Scope It
@@ -348,7 +348,7 @@ try
                 # This tests wrongly calls Set-ClusterOwnerNode and Move-ClusterGroup. See issue #97.
                 Context 'When Ensure is set to ''Absent'' and the preferred owner is not a possible owner of the cluster nodes and the cluster resources' {
                     It 'Should do nothing' {
-                        { Set-TargetResource @mockTestParameters_Absent_AndPreferredOwnersDoesNotExist } | Should Not Throw
+                        { Set-TargetResource @mockTestParameters_Absent_AndPreferredOwnersDoesNotExist } | Should -Not -Throw
 
                         # Called two times, one times for each node (2 nodes), and one time for each cluster resource (1 resource).
                         Assert-MockCalled -CommandName 'Set-ClusterOwnerNode' -Exactly -Times 3 -Scope It

--- a/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
@@ -192,18 +192,18 @@ try
 
                         It 'Should return the correct type' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                            $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                         }
 
                         It 'Should return the same values as passed as parameters' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.IsSingleInstance | Should Be $mockTestParameters.IsSingleInstance
+                            $getTargetResourceResult.IsSingleInstance | Should -Be $mockTestParameters.IsSingleInstance
                         }
 
                         It 'Should return the correct values' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.Type | Should Be $mockQuorumType_NodeMajority
-                            $getTargetResourceResult.Resource  | Should Be $mockQuorumResourceName
+                            $getTargetResourceResult.Type | Should -Be $mockQuorumType_NodeMajority
+                            $getTargetResourceResult.Resource  | Should -Be $mockQuorumResourceName
                         }
                     }
 
@@ -215,13 +215,13 @@ try
 
                         It 'Should return the same values as passed as parameters' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.IsSingleInstance | Should Be $mockTestParameters.IsSingleInstance
+                            $getTargetResourceResult.IsSingleInstance | Should -Be $mockTestParameters.IsSingleInstance
                         }
 
                         It 'Should return the correct values' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.Type | Should Be $mockQuorumType_NodeMajority
-                            $getTargetResourceResult.Resource  | Should BeNullorEmpty
+                            $getTargetResourceResult.Type | Should -Be $mockQuorumType_NodeMajority
+                            $getTargetResourceResult.Resource  | Should -BeNullorEmpty
                         }
                     }
                 }
@@ -234,13 +234,13 @@ try
 
                         It 'Should return the same values as passed as parameters' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.IsSingleInstance | Should Be $mockTestParameters.IsSingleInstance
+                            $getTargetResourceResult.IsSingleInstance | Should -Be $mockTestParameters.IsSingleInstance
                         }
 
                         It 'Should return the correct values' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.Type | Should Be $mockQuorumType_NodeAndDiskMajority
-                            $getTargetResourceResult.Resource  | Should Be $mockQuorumResourceName
+                            $getTargetResourceResult.Type | Should -Be $mockQuorumType_NodeAndDiskMajority
+                            $getTargetResourceResult.Resource  | Should -Be $mockQuorumResourceName
                         }
                     }
 
@@ -252,13 +252,13 @@ try
 
                         It 'Should return the same values as passed as parameters' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.IsSingleInstance | Should Be $mockTestParameters.IsSingleInstance
+                            $getTargetResourceResult.IsSingleInstance | Should -Be $mockTestParameters.IsSingleInstance
                         }
 
                         It 'Should return the correct values' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.Type | Should Be $mockQuorumType_NodeAndDiskMajority
-                            $getTargetResourceResult.Resource  | Should Be $mockQuorumResourceName
+                            $getTargetResourceResult.Type | Should -Be $mockQuorumType_NodeAndDiskMajority
+                            $getTargetResourceResult.Resource  | Should -Be $mockQuorumResourceName
                         }
                     }
                 }
@@ -271,13 +271,13 @@ try
 
                         It 'Should return the same values as passed as parameters' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.IsSingleInstance | Should Be $mockTestParameters.IsSingleInstance
+                            $getTargetResourceResult.IsSingleInstance | Should -Be $mockTestParameters.IsSingleInstance
                         }
 
                         It 'Should return the correct values' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.Type | Should Be $mockQuorumType_NodeAndFileShareMajority
-                            $getTargetResourceResult.Resource  | Should Be $mockQuorumFileShareWitnessPath
+                            $getTargetResourceResult.Type | Should -Be $mockQuorumType_NodeAndFileShareMajority
+                            $getTargetResourceResult.Resource  | Should -Be $mockQuorumFileShareWitnessPath
                         }
                     }
 
@@ -289,13 +289,13 @@ try
 
                         It 'Should return the same values as passed as parameters' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.IsSingleInstance | Should Be $mockTestParameters.IsSingleInstance
+                            $getTargetResourceResult.IsSingleInstance | Should -Be $mockTestParameters.IsSingleInstance
                         }
 
                         It 'Should return the correct values' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                            $getTargetResourceResult.Type | Should Be $mockQuorumType_NodeAndFileShareMajority
-                            $getTargetResourceResult.Resource  | Should Be $mockQuorumFileShareWitnessPath
+                            $getTargetResourceResult.Type | Should -Be $mockQuorumType_NodeAndFileShareMajority
+                            $getTargetResourceResult.Resource  | Should -Be $mockQuorumFileShareWitnessPath
                         }
                     }
                 }
@@ -307,13 +307,13 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.IsSingleInstance | Should Be $mockTestParameters.IsSingleInstance
+                        $getTargetResourceResult.IsSingleInstance | Should -Be $mockTestParameters.IsSingleInstance
                     }
 
                     It 'Should return the correct values' {
                         $getTargetResourceResult = Get-TargetResource @mockTestParameters
-                        $getTargetResourceResult.Type | Should Be $mockQuorumType_DiskOnly
-                        $getTargetResourceResult.Resource  | Should Be $mockQuorumResourceName
+                        $getTargetResourceResult.Type | Should -Be $mockQuorumType_DiskOnly
+                        $getTargetResourceResult.Resource  | Should -Be $mockQuorumResourceName
                     }
                 }
 
@@ -324,7 +324,7 @@ try
                         }
 
                         It 'Should throw the correct error message' {
-                            { Get-TargetResource @mockTestParameters } | Should Throw ('Unknown quorum type: {0}' -f $mockQuorumType_Unknown)
+                            { Get-TargetResource @mockTestParameters } | Should -Throw ('Unknown quorum type: {0}' -f $mockQuorumType_Unknown)
                         }
                     }
 
@@ -335,7 +335,7 @@ try
                         }
 
                         It 'Should throw the correct error message' {
-                            { Get-TargetResource @mockTestParameters } | Should Throw ('Unknown quorum resource: {0}' -f '@{Name=Witness; OwnerGroup=Cluster Group; ResourceType=}')
+                            { Get-TargetResource @mockTestParameters } | Should -Throw ('Unknown quorum resource: {0}' -f '@{Name=Witness; OwnerGroup=Cluster Group; ResourceType=}')
                         }
                     }
                 }
@@ -365,7 +365,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
 
@@ -379,7 +379,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
                 }
@@ -398,7 +398,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
 
@@ -411,7 +411,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
                 }
@@ -424,7 +424,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
 
@@ -436,7 +436,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
                 }
@@ -449,7 +449,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
 
@@ -461,7 +461,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
                     }
                 }
@@ -473,7 +473,7 @@ try
 
                     It 'Should return the value $false' {
                         $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
             }
@@ -493,7 +493,7 @@ try
 
                         It 'Should return the value $true' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $true
+                            $testTargetResourceResult | Should -Be $true
                         }
                     }
 
@@ -507,7 +507,7 @@ try
 
                         It 'Should return the value $true' {
                             $testTargetResourceResult = Test-TargetResource @mockTestParameters
-                            $testTargetResourceResult | Should Be $true
+                            $testTargetResourceResult | Should -Be $true
                         }
                     }
                 }
@@ -530,7 +530,7 @@ try
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
-                    { Set-TargetResource @mockTestParameters } |  Should Not Throw
+                    { Set-TargetResource @mockTestParameters } |  Should -Not -Throw
 
                     Assert-MockCalled -CommandName 'Set-ClusterQuorum' `
                                       -ParameterFilter $mockSetClusterQuorum_NoWitness_ParameterFilter `
@@ -551,7 +551,7 @@ try
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
-                    { Set-TargetResource @mockTestParameters } |  Should Not Throw
+                    { Set-TargetResource @mockTestParameters } |  Should -Not -Throw
 
                     Assert-MockCalled -CommandName 'Set-ClusterQuorum' `
                                       -ParameterFilter $mockSetClusterQuorum_DiskWitness_ParameterFilter `
@@ -572,7 +572,7 @@ try
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
-                    { Set-TargetResource @mockTestParameters } |  Should Not Throw
+                    { Set-TargetResource @mockTestParameters } |  Should -Not -Throw
 
                     Assert-MockCalled -CommandName 'Set-ClusterQuorum' `
                                       -ParameterFilter $mockSetClusterQuorum_FileShareWitness_ParameterFilter `
@@ -593,7 +593,7 @@ try
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
-                    { Set-TargetResource @mockTestParameters } |  Should Not Throw
+                    { Set-TargetResource @mockTestParameters } |  Should -Not -Throw
 
                     Assert-MockCalled -CommandName 'Set-ClusterQuorum' `
                                       -ParameterFilter $mockSetClusterQuorum_DiskOnly_ParameterFilter `

--- a/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForCluster.Tests.ps1
@@ -72,14 +72,14 @@ try
             Context 'When the system is either in the desired state or not in the desired state' {
                 It 'Returns a [System.Collection.Hashtable] type' {
                     $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
-                    $getTargetResourceResult | Should BeOfType [System.Collections.Hashtable]
+                    $getTargetResourceResult | Should -BeOfType [System.Collections.Hashtable]
                 }
 
                 It 'Returns the same values passed as parameters' {
                     $getTargetResourceResult = Get-TargetResource @mockDefaultParameters
-                    $getTargetResourceResult.Name              | Should Be $mockDefaultParameters.Name
-                    $getTargetResourceResult.RetryIntervalSec  | Should Be $mockDefaultParameters.RetryIntervalSec
-                    $getTargetResourceResult.RetryCount        | Should Be $mockDefaultParameters.RetryCount
+                    $getTargetResourceResult.Name              | Should -Be $mockDefaultParameters.Name
+                    $getTargetResourceResult.RetryIntervalSec  | Should -Be $mockDefaultParameters.RetryIntervalSec
+                    $getTargetResourceResult.RetryCount        | Should -Be $mockDefaultParameters.RetryCount
                 }
 
                 Assert-VerifiableMocks
@@ -94,7 +94,7 @@ try
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockCimInstance_ParameterFilter -Verifiable
 
                     $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message ($script:localizedData.ClusterAbsentAfterTimeOut -f $mockClusterName, ($mockRetryCount-1), $mockRetryIntervalSec)
-                    { Set-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
+                    { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
                 }
             }
 
@@ -116,7 +116,7 @@ try
 
                         It 'Should throw the correct error message' {
                             $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message ($script:localizedData.ClusterAbsentAfterTimeOut -f $mockClusterName, $mockRetryCount, $mockRetryIntervalSec)
-                            { Set-TargetResource @mockDefaultParameters } | Should Throw $mockCorrectErrorRecord
+                            { Set-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
                         }
 
                         Assert-VerifiableMocks
@@ -134,7 +134,7 @@ try
                     $mockDynamicDomainName = $mockDomainName
 
                     It 'Should not throw any error' {
-                        { Set-TargetResource @mockDefaultParameters } | Should Not Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
                     }
 
                     Assert-VerifiableMocks
@@ -152,7 +152,7 @@ try
 
                 It 'Should return the value $false' {
                     $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -170,7 +170,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
 
                         Assert-VerifiableMocks
@@ -188,7 +188,7 @@ try
 
                         It 'Should return the value $false' {
                             $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
                         }
 
                         Assert-VerifiableMocks
@@ -206,7 +206,7 @@ try
 
                     It 'Should return the value $true' {
                         $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
 
                     Assert-VerifiableMocks


### PR DESCRIPTION
**Pull Request (PR) description**
Update Pester syntax to v4 flags

**This Pull Request (PR) fixes the following issues:**
Resolves #149

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/152)
<!-- Reviewable:end -->
