### PR TITLE
xClusterQuorum: Added cloud witness functionality on Windows 2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Get-TargetResource now correctly returns the IP address instead of throwing
     and error ([issue #28](https://github.com/PowerShell/xFailOverCluster/issues/28)).
   - Added -IgnoreNetwork parameter ([issue #143](https://github.com/PowerShell/xFailOverCluster/issues/143)).
+  - Cleaned up tests which was using over complicated evaluation code.
 - Changes to xClusterQuorum
   - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run
     failed when Test-TargetResource validated the configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Changes to xClusterQuorum
   - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run
     failed when Test-TargetResource validated the configuration.
+  - Cleaned up tests which was using over complicated evaluation code.
 
 ## 1.8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
   - Get-TargetResource now correctly returns the IP address instead of throwing
     and error ([issue #28](https://github.com/PowerShell/xFailOverCluster/issues/28)).
   - Added -IgnoreNetwork parameter ([issue #143](https://github.com/PowerShell/xFailOverCluster/issues/143)).
-  - Cleaned up tests which was using over complicated evaluation code.
 - Changes to xClusterQuorum
   - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run
     failed when Test-TargetResource validated the configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - When using NodeAndFileShareMajority on Windows Server 2016 any subsequent run
     failed when Test-TargetResource validated the configuration.
   - Cleaned up tests which was using over complicated evaluation code.
+  - Added cloud witness (Azure storage) functionality on Windows 2016
+    ([issue #37](https://github.com/PowerShell/xFailOverCluster/issues/37)).
 
 ## 1.8.0.0
 

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
@@ -103,7 +103,7 @@ function Get-TargetResource
         IsSingleInstance        = $IsSingleInstance
         Type                    = $clusterQuorumType
         Resource                = $clusterQuorumResource
-        StorageAccountAccessKey = ""
+        StorageAccountAccessKey = ""    # Return an empty value since we cannot retrieve the current Access Key
     }
 }
 
@@ -125,6 +125,7 @@ function Get-TargetResource
     .PARAMETER StorageAccountAccessKey
         The access key of the Azure storage account to use as witness.
         This parameter is required if the quorum type is set to NodeAndCloudMajority.
+        The key is currently not updated if the resource is already set.
 #>
 function Set-TargetResource
 {
@@ -199,6 +200,7 @@ function Set-TargetResource
     .PARAMETER StorageAccountAccessKey
         The access key of the Azure storage account to use as witness.
         This parameter is required if the quorum type is set to NodeAndCloudMajority.
+        The key is currently not updated if the resource is already set.
         Not used in Test-TargetResource.
 #>
 function Test-TargetResource

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
@@ -115,11 +115,15 @@ function Get-TargetResource
 
     .PARAMETER Type
         Quorum type to use. Can be set to either NodeMajority, NodeAndDiskMajority,
-        NodeAndFileShareMajority or DiskOnly.
+        NodeAndFileShareMajority, NodeAndCloudMajority or DiskOnly.
 
     .PARAMETER Resource
         The name of the disk or file share resource to use as witness. This parameter
         is optional if the quorum type is set to NodeMajority.
+
+    .PARAMETER StorageAccountAccessKey
+        One of the keys of the Azure storage account, if you specify NodeAndCloudMajority
+        as the Quorum Type.
 #>
 function Set-TargetResource
 {
@@ -185,11 +189,15 @@ function Set-TargetResource
 
     .PARAMETER Type
         Quorum type to use. Can be set to either NodeMajority, NodeAndDiskMajority,
-        NodeAndFileShareMajority or DiskOnly.
+        NodeAndFileShareMajority, NodeAndCloudMajority or DiskOnly.
 
     .PARAMETER Resource
         The name of the disk or file share resource to use as witness. This parameter
         is optional if the quorum type is set to NodeMajority.
+
+    .PARAMETER StorageAccountAccessKey
+        One of the keys of the Azure storage account, if you specify NodeAndCloudMajority
+        as the Quorum Type.
 #>
 function Test-TargetResource
 {

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
@@ -100,9 +100,10 @@ function Get-TargetResource
     }
 
     @{
-        IsSingleInstance = $IsSingleInstance
-        Type             = $clusterQuorumType
-        Resource         = $clusterQuorumResource
+        IsSingleInstance        = $IsSingleInstance
+        Type                    = $clusterQuorumType
+        Resource                = $clusterQuorumResource
+        StorageAccountAccessKey = ""
     }
 }
 

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.psm1
@@ -118,12 +118,12 @@ function Get-TargetResource
         NodeAndFileShareMajority, NodeAndCloudMajority or DiskOnly.
 
     .PARAMETER Resource
-        The name of the disk or file share resource to use as witness. This parameter
-        is optional if the quorum type is set to NodeMajority.
+        The name of the disk, file share or Azure storage account resource to use
+        as witness. This parameter is optional if the quorum type is set to NodeMajority.
 
     .PARAMETER StorageAccountAccessKey
-        One of the keys of the Azure storage account, if you specify NodeAndCloudMajority
-        as the Quorum Type.
+        The access key of the Azure storage account to use as witness.
+        This parameter is required if the quorum type is set to NodeAndCloudMajority.
 #>
 function Set-TargetResource
 {
@@ -192,12 +192,13 @@ function Set-TargetResource
         NodeAndFileShareMajority, NodeAndCloudMajority or DiskOnly.
 
     .PARAMETER Resource
-        The name of the disk or file share resource to use as witness. This parameter
-        is optional if the quorum type is set to NodeMajority.
+        The name of the disk, file share or Azure storage account resource to use
+        as witness. This parameter is optional if the quorum type is set to NodeMajority.
 
     .PARAMETER StorageAccountAccessKey
-        One of the keys of the Azure storage account, if you specify NodeAndCloudMajority
-        as the Quorum Type.
+        The access key of the Azure storage account to use as witness.
+        This parameter is required if the quorum type is set to NodeAndCloudMajority.
+        Not used in Test-TargetResource.
 #>
 function Test-TargetResource
 {

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.schema.mof
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.schema.mof
@@ -2,6 +2,7 @@
 class MSFT_xClusterQuorum : OMI_BaseResource
 {
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] string IsSingleInstance;
-    [Write, Description("Quorum type to use. Can be set to either NodeMajority, NodeAndDiskMajority, NodeAndFileShareMajority or DiskOnly."), ValueMap{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "DiskOnly"}, Values{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "DiskOnly"}] string Type;
-    [Write, Description("The name of the disk or file share resource to use as witness. This parameter is optional if the quorum type is set to NodeMajority.")] String Resource;
+    [Write, Description("Quorum type to use. Can be set to either NodeMajority, NodeAndDiskMajority, NodeAndFileShareMajority, NodeAndCloudMajority or DiskOnly."), ValueMap{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "NodeAndCloudMajority", "DiskOnly"}, Values{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "NodeAndCloudMajority", "DiskOnly"}] string Type;
+    [Write, Description("The name of the disk, file share or Azure storage account resource to use as witness. This parameter is optional if the quorum type is set to NodeMajority.")] String Resource;
+    [Write, Description("The access key of the Azure storage account to use as witness. This parameter is required if the quorum type is set to NodeAndCloudMajority.")] String StorageAccountAccessKey;
 };

--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.schema.mof
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.schema.mof
@@ -4,5 +4,5 @@ class MSFT_xClusterQuorum : OMI_BaseResource
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] string IsSingleInstance;
     [Write, Description("Quorum type to use. Can be set to either NodeMajority, NodeAndDiskMajority, NodeAndFileShareMajority, NodeAndCloudMajority or DiskOnly."), ValueMap{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "NodeAndCloudMajority", "DiskOnly"}, Values{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "NodeAndCloudMajority", "DiskOnly"}] string Type;
     [Write, Description("The name of the disk, file share or Azure storage account resource to use as witness. This parameter is optional if the quorum type is set to NodeMajority.")] String Resource;
-    [Write, Description("The access key of the Azure storage account to use as witness. This parameter is required if the quorum type is set to NodeAndCloudMajority.")] String StorageAccountAccessKey;
+    [Write, Description("The access key of the Azure storage account to use as witness. This parameter is required if the quorum type is set to NodeAndCloudMajority. The key is currently not updated if the resource is already set.")] String StorageAccountAccessKey;
 };

--- a/Examples/Resources/xClusterQuorum/5-SetQuorumToNodeAndCloudMajority.ps1
+++ b/Examples/Resources/xClusterQuorum/5-SetQuorumToNodeAndCloudMajority.ps1
@@ -1,0 +1,29 @@
+<#
+.EXAMPLE
+    This example shows how to set the quorum in a failover cluster to use
+    node and cloud majority.
+
+    This example assumes the failover cluster is already present.
+
+    This example also assumes that the Azure storage account 'myazurestorageaccount'
+    is already present.
+    An Azure storage account has 2 connection keys. Only one is needed for configuration.
+    Here is a link for setting up the high availability with cloud witness
+    https://docs.microsoft.com/en-us/windows-server/failover-clustering/deploy-cloud-witness
+#>
+
+Configuration Example
+{
+    Import-DscResource -ModuleName xFailOverCluster
+
+    Node localhost
+    {
+        xClusterQuorum 'SetQuorumToNodeAndCloudMajority'
+        {
+            IsSingleInstance        = 'Yes'
+            Type                    = 'NodeAndCloudMajority'
+            Resource                = 'myazurestorageaccount'
+            StorageAccountAccessKey = '8gxPaXynG5onrfpuob+M+5wBE7ow01CjdyOw7rj3DbepsK/tt3kr1GOuqJhARCPeyAQmfW8WsTCOGFwAYUVw/Q=='
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -186,10 +186,13 @@ quorum type, please see the article
 * **`[String]` IsSingleInstance** _(Key)_: Specifies the resource is a single
   instance, the value must be 'Yes'.
 * **`[String]` Type** _(Write)_: Quorum type to use. { NodeMajority |
-  NodeAndDiskMajority | NodeAndFileShareMajority, DiskOnly }.
-* **`[String]` Resource** _(Write)_: The name of the disk or file share resource
-  to use as witness. This parameter is optional if the quorum type is set to
-  NodeMajority.
+  NodeAndDiskMajority | NodeAndFileShareMajority | NodeAndCloudMajority, DiskOnly }.
+* **`[String]` Resource** _(Write)_: The name of the disk, file share or Azure
+  storage account resource to use as witness. This parameter is optional if the
+  quorum type is set to NodeMajority.
+* **`[String]` StorageAccountAccessKey** _(Write)_: The access key of the Azure
+  storage account to use as witness. This parameter is required if the quorum
+  type is set to NodeAndCloudMajority.
 
 #### Examples for xClusterQuorum
 
@@ -197,6 +200,7 @@ quorum type, please see the article
 * [Set quorum to node and disk majority](/Examples/Resources/xClusterQuorum/2-SetQuorumToNodeAndDiskMajority.ps1)
 * [Set quorum to node and file share majority](/Examples/Resources/xClusterQuorum/3-SetQuorumToNodeAndFileShareMajority.ps1)
 * [Set quorum to disk only](/Examples/Resources/xClusterQuorum/4-SetQuorumToDiskOnly.ps1)
+* [Set quorum to node and cloud](/Examples/Resources/xClusterQuorum/5-SetQuorumToNodeAndCloudMajority.1)
 
 ### xWaitForCluster
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ quorum type, please see the article
   quorum type is set to NodeMajority.
 * **`[String]` StorageAccountAccessKey** _(Write)_: The access key of the Azure
   storage account to use as witness. This parameter is required if the quorum
-  type is set to NodeAndCloudMajority.
+  type is set to NodeAndCloudMajority. The key is currently not updated if the
+  resource is already set.
 
 #### Examples for xClusterQuorum
 

--- a/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
@@ -566,8 +566,6 @@ try
             Context 'When quorum type should be NodeMajority' {
                 BeforeEach {
                     $mockTestParameters['Type'] = $mockQuorumType_NodeMajority
-
-                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -585,7 +583,6 @@ try
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
                     $mockDynamicQuorumResourceName = $mockQuorumResourceName
-                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeAndDiskMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -603,7 +600,6 @@ try
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
                     $mockDynamicQuorumResourceName = $mockQuorumResourceName
-                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -622,7 +618,6 @@ try
                     $mockTestParameters['StorageAccountAccessKey'] = $mockQuorumAccessKey
 
                     $mockDynamicQuorumResourceName = $mockQuorumAccountName
-                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -640,7 +635,6 @@ try
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
                     $mockDynamicQuorumResourceName = $mockQuorumResourceName
-                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_DiskOnly
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {

--- a/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
@@ -48,6 +48,7 @@ try
 
         $mockQuorumResourceName = 'Witness'
         $mockQuorumFileShareWitnessPath = '\\FILE01\CLUSTER01'
+        $mockQuorumAccountName = 'AccountName'
         $mockQuorumAccessKey = 'USRuD354YbOHkPI35SUVyMj2W3odWekMIEdj3n2qAbc0yzqwpMwH-+M+GHJ27OuA5FkTxsbBF9qGc6r6UM3ipg=='
 
         $mockGetClusterQuorum = {
@@ -94,7 +95,7 @@ try
             $getClusterQuorumReturnValue
         }
 
-        $mockGetClusterParameter = {
+        $mockGetClusterParameter_SharePath = {
             @(
                 [PSCustomObject] @{
                     ClusterObject = $mockDynamicQuorumTypeDisplayName
@@ -106,8 +107,24 @@ try
             )
         }
 
-        $mockGetClusterParameter_ParameterFilter = {
+        $mockGetClusterParameter_SharePath_ParameterFilter = {
             $Name -eq 'SharePath'
+        }
+
+        $mockGetClusterParameter_AccountName = {
+            @(
+                [PSCustomObject] @{
+                    ClusterObject = 'File Share Witness'
+                    Name          = 'AccountName'
+                    IsReadOnly    = 'False'
+                    ParameterType = 'String'
+                    Value         = $mockQuorumAccountName
+                }
+            )
+        }
+
+        $mockGetClusterParameter_AccountName_ParameterFilter = {
+            $Name -eq 'AccountName'
         }
 
         $mockSetClusterQuorum_NoWitness_ParameterFilter = {
@@ -115,77 +132,21 @@ try
         }
 
         $mockSetClusterQuorum_DiskWitness_ParameterFilter = {
-            $PSBoundParameters.ContainsKey('DiskWitness') -eq $true
+            $DiskWitness -eq $mockQuorumResourceName
         }
 
         $mockSetClusterQuorum_FileShareWitness_ParameterFilter = {
-            $PSBoundParameters.ContainsKey('FileShareWitness') -eq $true
+            $FileShareWitness -eq $mockQuorumResourceName
         }
 
         $mockSetClusterQuorum_DiskOnly_ParameterFilter = {
-            $PSBoundParameters.ContainsKey('DiskOnly') -eq $true
+            $DiskOnly -eq $mockQuorumResourceName
         }
 
         $mockSetClusterQuorum_CloudWitness_ParameterFilter = {
-            $PSBoundParameters.ContainsKey('CloudWitness') -eq $true
-        }
-
-        $mockSetClusterQuorum = {
-            $wrongParameters = $false
-
-            # Evaluate if the Set-ClusterQuorum is called with the correct parameters.
-            switch ($mockDynamicSetClusterQuorum_ExpectedQuorumType)
-            {
-                $mockQuorumType_NodeMajority
-                {
-                    if (-not $NoWitness)
-                    {
-                        $wrongParameters = $true
-                    }
-                }
-
-                $mockQuorumType_NodeAndDiskMajority
-                {
-                    if ($DiskWitness -ne $mockDynamicQuorumResourceName)
-                    {
-                        $wrongParameters = $true
-                    }
-                }
-
-                $mockQuorumType_NodeAndFileShareMajority
-                {
-                    if ($FileShareWitness -ne $mockDynamicQuorumResourceName)
-                    {
-                        $wrongParameters = $true
-                    }
-                }
-
-                $mockQuorumType_DiskOnly
-                {
-                    if ($DiskOnly -ne $mockDynamicQuorumResourceName)
-                    {
-                        $wrongParameters = $true
-                    }
-                }
-
-                $mockQuorumType_CloudWitness
-                {
-                    if ($CloudWitness -ne $mockDynamicQuorumResourceName)
-                    {
-                        $wrongParameters = $true
-                    }
-                }
-
-                default
-                {
-                    $wrongParameters = $true
-                }
-            }
-
-            if ($wrongParameters)
-            {
-                throw 'Mock Set-ClusterQuorum was called with the wrong parameters.'
-            }
+            $CloudWitness -eq $true `
+            -and $AccountName -eq $mockQuorumAccountName `
+            -and $AccessKey -eq $mockQuorumAccessKey
         }
 
         $mockDefaultParameters = @{
@@ -195,7 +156,8 @@ try
         Describe 'xClusterQuorum\Get-TargetResource' {
             BeforeEach {
                 Mock -CommandName 'Get-ClusterQuorum' -MockWith $mockGetClusterQuorum
-                Mock -CommandName 'Get-ClusterParameter' -MockWith $mockGetClusterParameter -ParameterFilter $mockGetClusterParameter_ParameterFilter
+                Mock -CommandName 'Get-ClusterParameter' -MockWith $mockGetClusterParameter_SharePath -ParameterFilter $mockGetClusterParameter_SharePath_ParameterFilter
+                Mock -CommandName 'Get-ClusterParameter' -MockWith $mockGetClusterParameter_AccountName -ParameterFilter $mockGetClusterParameter_AccountName_ParameterFilter
 
                 $mockTestParameters = $mockDefaultParameters.Clone()
             }
@@ -337,7 +299,7 @@ try
                         It 'Should return the correct values' {
                             $getTargetResourceResult = Get-TargetResource @mockTestParameters
                             $getTargetResourceResult.Type | Should -Be $mockQuorumType_NodeAndCloudMajority
-                            $getTargetResourceResult.Resource  | Should -Be $mockQuorumResourceName
+                            $getTargetResourceResult.Resource  | Should -Be $mockQuorumAccountName
                         }
                     }
                 }
@@ -387,7 +349,8 @@ try
         Describe 'xClusterQuorum\Test-TargetResource' {
             BeforeEach {
                 Mock -CommandName 'Get-ClusterQuorum' -MockWith $mockGetClusterQuorum
-                Mock -CommandName 'Get-ClusterParameter' -MockWith $mockGetClusterParameter -ParameterFilter $mockGetClusterParameter_ParameterFilter
+                Mock -CommandName 'Get-ClusterParameter' -MockWith $mockGetClusterParameter_SharePath -ParameterFilter $mockGetClusterParameter_SharePath_ParameterFilter
+                Mock -CommandName 'Get-ClusterParameter' -MockWith $mockGetClusterParameter_AccountName -ParameterFilter $mockGetClusterParameter_AccountName_ParameterFilter
 
                 $mockTestParameters = $mockDefaultParameters.Clone()
             }
@@ -509,17 +472,15 @@ try
                     }
                 }
 
-                Context 'When quorum type is NodeAndCloudMajority but the resource is not in desired state' {
-                    BeforeEach {
-                        $mockTestParameters['Type'] = $mockQuorumType_NodeAndCloudMajority
-                        $mockTestParameters['Resource'] = $mockQuorumResourceName
-                        $mockTestParameters['StorageAccountAccessKey'] = $mockQuorumAccessKey
-                    }
-
+                Context 'When desired state should be NodeAndCloudMajority' {
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
-                            $mockDynamicQuorumType = $mockQuorumType_NodeAndCloudMajority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
+                            $mockDynamicQuorumType = $mockQuorumType_Majority
+                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+
+                            $mockTestParameters['Type'] = $mockQuorumType_NodeAndCloudMajority
+                            $mockTestParameters['Resource'] = $mockQuorumAccountName
+                            $mockTestParameters['StorageAccountAccessKey'] = $mockQuorumAccessKey
                         }
 
                         It 'Should return the value $false' {
@@ -573,20 +534,37 @@ try
                             $testTargetResourceResult | Should -Be $true
                         }
                     }
+
+                    Context 'When desired state should be NodeAndCloudMajority' {
+                        Context 'When target node is Windows Server 2016 and newer' {
+                            BeforeEach {
+                                $mockDynamicQuorumType = $mockQuorumType_Majority
+                                $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
+
+                                $mockTestParameters['Type'] = $mockQuorumType_NodeAndCloudMajority
+                                $mockTestParameters['Resource'] = $mockQuorumAccountName
+                                $mockTestParameters['StorageAccountAccessKey'] = $mockQuorumAccessKey
+                            }
+
+                            It 'Should return the value $false' {
+                                $testTargetResourceResult = Test-TargetResource @mockTestParameters
+                                $testTargetResourceResult | Should -Be $true
+                            }
+                        }
+                    }
                 }
             }
         }
 
         Describe 'xClusterQuorum\Set-TargetResource' {
             BeforeEach {
+                Mock -CommandName 'Set-ClusterQuorum'
+
                 $mockTestParameters = $mockDefaultParameters.Clone()
             }
 
             Context 'When quorum type should be NodeMajority' {
                 BeforeEach {
-                    Mock -CommandName 'Set-ClusterQuorum' -MockWith $mockSetClusterQuorum `
-                        -ParameterFilter $mockSetClusterQuorum_NoWitness_ParameterFilter
-
                     $mockTestParameters['Type'] = $mockQuorumType_NodeMajority
 
                     $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeMajority
@@ -603,9 +581,6 @@ try
 
             Context 'When quorum type should be NodeMajority' {
                 BeforeEach {
-                    Mock -CommandName 'Set-ClusterQuorum' -MockWith $mockSetClusterQuorum `
-                        -ParameterFilter $mockSetClusterQuorum_DiskWitness_ParameterFilter
-
                     $mockTestParameters['Type'] = $mockQuorumType_NodeAndDiskMajority
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
@@ -624,9 +599,6 @@ try
 
             Context 'When quorum type should be NodeMajority' {
                 BeforeEach {
-                    Mock -CommandName 'Set-ClusterQuorum' -MockWith $mockSetClusterQuorum `
-                        -ParameterFilter $mockSetClusterQuorum_FileShareWitness_ParameterFilter
-
                     $mockTestParameters['Type'] = $mockQuorumType_NodeAndFileShareMajority
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 
@@ -645,14 +617,12 @@ try
 
             Context 'When quorum type should be NodeAndCloudMajority' {
                 BeforeEach {
-                    Mock -CommandName 'Set-ClusterQuorum' -MockWith $mockSetClusterQuorum `
-                        -ParameterFilter $mockSetClusterQuorum_CloudWitness_ParameterFilter
                     $mockTestParameters['Type'] = $mockQuorumType_NodeAndCloudMajority
-                    $mockTestParameters['Resource'] = $mockQuorumResourceName
+                    $mockTestParameters['Resource'] = $mockQuorumAccountName
                     $mockTestParameters['StorageAccountAccessKey'] = $mockQuorumAccessKey
 
-                    $mockDynamicQuorumResourceName = $mockQuorumResourceName
-                    $mockDynamicSetClusterQuorum_ExcpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
+                    $mockDynamicQuorumResourceName = $mockQuorumAccountName
+                    $mockDynamicSetClusterQuorum_ExpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
                 }
 
                 It 'Should set the quorum in the cluster without throwing an error' {
@@ -666,9 +636,6 @@ try
 
             Context 'When quorum type should be NodeMajority' {
                 BeforeEach {
-                    Mock -CommandName 'Set-ClusterQuorum' -MockWith $mockSetClusterQuorum `
-                        -ParameterFilter $mockSetClusterQuorum_DiskOnly_ParameterFilter
-
                     $mockTestParameters['Type'] = $mockQuorumType_DiskOnly
                     $mockTestParameters['Resource'] = $mockQuorumResourceName
 

--- a/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
@@ -475,8 +475,8 @@ try
                 Context 'When desired state should be NodeAndCloudMajority' {
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
-                            $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+                            $mockDynamicQuorumType = $mockQuorumType_NodeMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
 
                             $mockTestParameters['Type'] = $mockQuorumType_NodeAndCloudMajority
                             $mockTestParameters['Resource'] = $mockQuorumAccountName

--- a/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterQuorum.Tests.ps1
@@ -288,7 +288,7 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
                         }
 
                         It 'Should return the same values as passed as parameters' {
@@ -476,7 +476,7 @@ try
                     Context 'When target node is Windows Server 2016 and newer' {
                         BeforeEach {
                             $mockDynamicQuorumType = $mockQuorumType_Majority
-                            $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
+                            $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndFileShareMajority
 
                             $mockTestParameters['Type'] = $mockQuorumType_NodeAndCloudMajority
                             $mockTestParameters['Resource'] = $mockQuorumAccountName
@@ -539,7 +539,7 @@ try
                         Context 'When target node is Windows Server 2016 and newer' {
                             BeforeEach {
                                 $mockDynamicQuorumType = $mockQuorumType_Majority
-                                $mockDynamicExcpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
+                                $mockDynamicExpectedQuorumType = $mockQuorumType_NodeAndCloudMajority
 
                                 $mockTestParameters['Type'] = $mockQuorumType_NodeAndCloudMajority
                                 $mockTestParameters['Resource'] = $mockQuorumAccountName


### PR DESCRIPTION
**Pull Request (PR) description**
Added possibility to use a "cloud witness", i.e. an Azure storage account, for a Windows 2016 cluster.
Based on documentation: https://docs.microsoft.com/en-us/windows-server/failover-clustering/deploy-cloud-witness
The storage account name is provided through the existing parameter "Resource".
An additional (optional) parameter has been created for the storage account key.
The standard endpoint (.blob.core.microsoft.net) is used. This parameter cannot be overriden in this release.

**This Pull Request (PR) fixes the following issues:**
Fixes: #37 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/153)
<!-- Reviewable:end -->
