### PR TITLE
xClusterQuorum: Add Cloud Witness to WSFC in W2016

### DIFF
--- a/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.schema.mof
+++ b/DSCResources/MSFT_xClusterQuorum/MSFT_xClusterQuorum.schema.mof
@@ -1,7 +1,13 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xClusterQuorum")]
 class MSFT_xClusterQuorum : OMI_BaseResource
 {
-    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] string IsSingleInstance;
-    [Write, Description("Quorum type to use. Can be set to either NodeMajority, NodeAndDiskMajority, NodeAndFileShareMajority or DiskOnly."), ValueMap{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "DiskOnly"}, Values{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "DiskOnly"}] string Type;
-    [Write, Description("The name of the disk or file share resource to use as witness. This parameter is optional if the quorum type is set to NodeMajority.")] String Resource;
+    [Key, ValueMap{"Yes"}, Values{"Yes"}] string IsSingleInstance;
+
+    [Write, ValueMap{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "DiskOnly", "Cloud Witness"}, Values{"NodeMajority", "NodeAndDiskMajority", "NodeAndFileShareMajority", "DiskOnly", "Cloud Witness"}] string Type;
+
+    [Write] String Resource;
+	
+	[Write] String StorageAccountName;
+	
+	[Write] String StorageAccountAccessKey;
 };


### PR DESCRIPTION
Adding the ability to pass Azure storage account details to create a cloud witness during the creation of a WSFC

<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please prefix the PR title with the resource name, i.e. 'xCluster: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xCluster: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
Adding the ability to pass Azure storage account details to create a cloud witness during the creation of a WSFC

**This Pull Request (PR) fixes the following issues:**
<!-- Replace this with the list of issues or n/a. Use format: Fixes #123 -->

**Task list:**
- [ ] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/160)
<!-- Reviewable:end -->
