### PR TITLE
xCluster: Fix parameter type qualifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the target node ($env:COMPUTERNAME) to the cluster.
 #### Parameters for xCluster
 
 * **`[String]` Name** _(Key)_: Name of the failover cluster.
-* **`[String]` StaticIPAddress** _(Required)_: The static IP address of the failover
+* **`[String]` StaticIPAddress** _(Write)_: The static IP address of the failover
   cluster. If this is not specified then the IP address will be assigned from a
   DHCP.
 * **`[String]` DomainAdministratorCredential** _(Required)_: Credential used to


### PR DESCRIPTION
**Pull Request (PR) description**
- This fixes the type qualifier for parameter StaticIPAddress that was recently merged.

***Note:** Skipping CHANGELOG.md for this since there are already an entry for this in the Unreleased section.*

**This Pull Request (PR) fixes the following issues:**
<!-- Replace this with the list of issues or n/a. Use format: Fixes #123 -->

**Task list:**
- [ ] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/165)
<!-- Reviewable:end -->
