### PR TITLE
xClusterNetwork: Fix Role property never in desired state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Changes to xClusterNetwork
+  - Fix the test for the network role never in desired state ([issue #175](https://github.com/PowerShell/xFailOverCluster/issues/175)).
+
 ## 1.9.0.0
 
 - Changes to xFailoverCluster

--- a/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
+++ b/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
@@ -34,17 +34,18 @@ function Get-TargetResource
         $_.Address -eq $Address -and $_.AddressMask -eq $AddressMask
     }
 
-    try
+    <#
+        On Windows Server 2008 R2 and on Windows Server 2012 R2, the property
+        Role is of type System.UInt32. On Windows Server 2016, the property Role
+        is of type Microsoft.FailoverClusters.PowerShell.ClusterNetworkRole.
+    #>
+    if ($NetworkResource.Role -is [System.UInt32])
     {
-        # Try to convert the role to it's enum value
-        $role = [String] [Int32] $NetworkResource.Role
-    }
-    catch
-    {
-        Write-Warning -Message ($script:localizedData.UnexpectedNetworkRole -f $NetworkResource.Role)
-
-        # Fallback, us the raw value
         $role = $NetworkResource.Role
+    }
+    else
+    {
+        $role = $NetworkResource.Role.value__
     }
 
     @{

--- a/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
+++ b/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
@@ -41,6 +41,8 @@ function Get-TargetResource
     }
     catch
     {
+        Write-Warning -Message ($script:localizedData.UnexpectedNetworkRole -f $NetworkResource.Role)
+
         # Fallback, us the raw value
         $role = $NetworkResource.Role
     }

--- a/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
+++ b/DSCResources/MSFT_xClusterNetwork/MSFT_xClusterNetwork.psm1
@@ -34,11 +34,22 @@ function Get-TargetResource
         $_.Address -eq $Address -and $_.AddressMask -eq $AddressMask
     }
 
+    try
+    {
+        # Try to convert the role to it's enum value
+        $role = [String] [Int32] $NetworkResource.Role
+    }
+    catch
+    {
+        # Fallback, us the raw value
+        $role = $NetworkResource.Role
+    }
+
     @{
         Address     = $Address
         AddressMask = $AddressMask
         Name        = $NetworkResource.Name
-        Role        = $NetworkResource.Role
+        Role        = $role
         Metric      = $NetworkResource.Metric
     }
 }

--- a/DSCResources/MSFT_xClusterNetwork/en-US/MSFT_xClusterNetwork.strings.psd1
+++ b/DSCResources/MSFT_xClusterNetwork/en-US/MSFT_xClusterNetwork.strings.psd1
@@ -6,4 +6,5 @@ ConvertFrom-StringData @'
     ChangeNetworkMetric = Changing the metric of the network {0}/{1} to '{2}'.
     GetClusterNetworkInformation = Retrieving information for cluster network {0}.
     EvaluatingClusterNetworkInformation = Evaluating state of cluster network {0}.
+    UnexpectedNetworkRole = Unexpected value for the network role: {0}.
 '@

--- a/DSCResources/MSFT_xClusterNetwork/en-US/MSFT_xClusterNetwork.strings.psd1
+++ b/DSCResources/MSFT_xClusterNetwork/en-US/MSFT_xClusterNetwork.strings.psd1
@@ -6,5 +6,4 @@ ConvertFrom-StringData @'
     ChangeNetworkMetric = Changing the metric of the network {0}/{1} to '{2}'.
     GetClusterNetworkInformation = Retrieving information for cluster network {0}.
     EvaluatingClusterNetworkInformation = Evaluating state of cluster network {0}.
-    UnexpectedNetworkRole = Unexpected value for the network role: {0}.
 '@

--- a/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
@@ -39,13 +39,13 @@ try
         $mockPresentClusterNetworkName = 'Client1'
         $mockPresentClusterNetworkAddress = '10.0.0.0'
         $mockPresentClusterNetworkAddressMask = '255.255.255.0'
-        $mockPresentClusterNetworkRole = '1'
+        $mockPresentClusterNetworkRole = [System.UInt32] 1
         $mockPresentClusterNetworkMetric = '70240'
 
         $mockAbsentClusterNetworkName = 'Client2'
         $mockAbsentClusterNetworkAddress = '10.0.0.0'
         $mockAbsentClusterNetworkAddressMask = '255.255.255.0'
-        $mockAbsentClusterNetworkRole = '3'
+        $mockAbsentClusterNetworkRole = [System.UInt32] 3
         $mockAbsentClusterNetworkMetric = '10'
 
         $mockGetClusterNetwork = {

--- a/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
@@ -161,6 +161,17 @@ try
 
                     Assert-MockCalled -CommandName Get-ClusterNetwork -Exactly -Times 1 -Scope It
                 }
+
+                It 'Should return the the correct values for the cluster network role on WS2016' {
+                    Mock -CommandName 'Get-ClusterNetwork' -MockWith $mockGetClusterNetwork2
+
+                    $Result = Get-TargetResource @mockTestParameters
+                    $Result.Name         | Should -Be $mockPresentClusterNetworkName
+                    $Result.Role         | Should -Be $mockPresentClusterNetworkRole
+                    $Result.Metric       | Should -Be $mockPresentClusterNetworkMetric
+
+                    Assert-MockCalled -CommandName Get-ClusterNetwork -Exactly -Times 1 -Scope It
+                }
             }
         }
         Describe 'xClusterNetwork\Test-TargetResource' {

--- a/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xClusterNetwork.Tests.ps1
@@ -40,6 +40,7 @@ try
         $mockPresentClusterNetworkAddress = '10.0.0.0'
         $mockPresentClusterNetworkAddressMask = '255.255.255.0'
         $mockPresentClusterNetworkRole = [System.UInt32] 1
+        $mockPresentClusterNetworkRole2 = [PSCustomObject] @{ value__ = 1 }
         $mockPresentClusterNetworkMetric = '70240'
 
         $mockAbsentClusterNetworkName = 'Client2'
@@ -55,6 +56,19 @@ try
                 Address     = $mockPresentClusterNetworkAddress
                 AddressMask = $mockPresentClusterNetworkAddressMask
                 Role        = $mockPresentClusterNetworkRole
+                Metric      = $mockPresentClusterNetworkMetric
+            } | Add-Member -MemberType ScriptMethod -Name Update -Value {
+                $script:mockNumerOfTimesMockedMethodUpdateWasCalled += 1
+            } -PassThru
+        }
+
+        $mockGetClusterNetwork2 = {
+            [PSCustomObject] @{
+                Cluster     = 'CLUSTER01'
+                Name        = $mockPresentClusterNetworkName
+                Address     = $mockPresentClusterNetworkAddress
+                AddressMask = $mockPresentClusterNetworkAddressMask
+                Role        = $mockPresentClusterNetworkRole2
                 Metric      = $mockPresentClusterNetworkMetric
             } | Add-Member -MemberType ScriptMethod -Name Update -Value {
                 $script:mockNumerOfTimesMockedMethodUpdateWasCalled += 1
@@ -100,6 +114,17 @@ try
                 }
 
                 It 'Should not return the the correct values for the cluster network' {
+                    $getTargetResourceResult = Get-TargetResource @mockTestParameters
+                    $getTargetResourceResult.Name         | Should -Not -Be $mockAbsentClusterNetworkName
+                    $getTargetResourceResult.Role         | Should -Not -Be $mockAbsentClusterNetworkRole
+                    $getTargetResourceResult.Metric       | Should -Not -Be $mockAbsentClusterNetworkMetric
+
+                    Assert-MockCalled -CommandName Get-ClusterNetwork -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should not return the the correct values for the cluster network role on WS2016' {
+                    Mock -CommandName 'Get-ClusterNetwork' -MockWith $mockGetClusterNetwork2
+
                     $getTargetResourceResult = Get-TargetResource @mockTestParameters
                     $getTargetResourceResult.Name         | Should -Not -Be $mockAbsentClusterNetworkName
                     $getTargetResourceResult.Role         | Should -Not -Be $mockAbsentClusterNetworkRole


### PR DESCRIPTION
**Pull Request (PR) description**
Convert the network role to the enum value if it returns a stirng, e.g. on WS2016.

**This Pull Request (PR) fixes the following issues:**
Fixes #175 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/176)
<!-- Reviewable:end -->
