### PR TITLE
xCluster: add Nodes parameter (enables cluster creation with several nodes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - Added xClusterProperty ([issue #169](https://github.com/PowerShell/xFailOverCluster/issues/169)).
 - Changes to xClusterNetwork
   - Fix the test for the network role never in desired state ([issue #175](https://github.com/PowerShell/xFailOverCluster/issues/175)).
+- Changes to xCluster
+  - Added a node parameter to be able to create a cluster with multiple nodes ([issue #148 (https://github.com/PowerShell/xFailOverCluster/issues/148), issue #157 (https://github.com/PowerShell/xFailOverCluster/issues/157))
 
 ## 1.9.0.0
 

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -228,11 +228,16 @@ function Set-TargetResource
             {
                 foreach ($targetNodeName in $AllNodes)
                 {
-                    if ($node.Name -eq $targetNodeName -and $node.State -eq 'Down')
+                    if ($node.Name -eq $targetNodeName)
                     {
-                        Write-Verbose -Message ($script:localizedData.RemoveOfflineNodeFromCluster -f $targetNodeName, $Name)
+                        if($node.State -eq 'Down')
+                        {
+                            Write-Verbose -Message ($script:localizedData.RemoveOfflineNodeFromCluster -f $targetNodeName, $Name)
 
-                        Remove-ClusterNode -Name $targetNodeName -Cluster $Name -Force
+                            Remove-ClusterNode -Name $targetNodeName -Cluster $Name -Force
+                        }
+
+                        break
                     }
                 }
             }
@@ -357,12 +362,14 @@ function Test-TargetResource
 
             $AllNodes = Get-All-Nodes($Nodes)
 
-            foreach ($node in $existingNodes)
+            foreach($targetNodeName in $AllNodes)
             {
-                foreach($targetNodeName in $AllNodes)
+                $found = $false
+                foreach ($node in $existingNodes)
                 {
                     if ($node.Name -eq $targetNodeName)
                     {
+                        $found = $true
                         if ($node.State -eq 'Down')
                         {
                             Write-Verbose -Message ($script:localizedData.ClusterNodeIsDown -f $targetNodeName, $Name)
@@ -371,6 +378,12 @@ function Test-TargetResource
 
                         break
                     }
+                }
+
+                if($false -eq $found)
+                {
+                    $returnValue = $false
+                    break
                 }
             }
 

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -514,7 +514,8 @@ function Close-UserToken
     .PARAMETER Nodes
         Array with node names
 #>
-function Get-All-Nodes {
+function Get-All-Nodes
+{
     [OutputType([String[]])]
     param
     (
@@ -526,7 +527,7 @@ function Get-All-Nodes {
     $AllNodes = @()
     $AllNodes += $env:COMPUTERNAME
 
-    if($Nodes -ne $null)
+    if($null -ne $Nodes)
     {
         $AllNodes += $Nodes
     }

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -519,7 +519,7 @@ function Get-All-Nodes
     [OutputType([String[]])]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [String[]]
         $Nodes
     )

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -179,15 +179,15 @@ function Set-TargetResource
     {
         ($oldToken, $context, $newToken) = Set-ImpersonateAs -Credential $DomainAdministratorCredential
 
+        $allNodes = Get-AllNodes -Nodes $Nodes
+
         if ($bCreate)
         {
             Write-Verbose -Message ($script:localizedData.ClusterAbsent -f $Name)
 
-
-
             $newClusterParameters = @{
               Name          = $Name
-              Node          = $AllNodes
+              Node          = $allNodes
               NoStorage     = $true
               Force         = $true
               ErrorAction   = 'Stop'
@@ -219,18 +219,16 @@ function Set-TargetResource
         }
         else
         {
-            $AllNodes = Get-All-Nodes($Nodes)
-
             Write-Verbose -Message ($script:localizedData.AddNodeToCluster -f $targetNodeName, $Name)
 
             $existingNodes = Get-ClusterNode -Cluster $Name
             foreach ($node in $existingNodes)
             {
-                foreach ($targetNodeName in $AllNodes)
+                foreach ($targetNodeName in $allNodes)
                 {
                     if ($node.Name -eq $targetNodeName)
                     {
-                        if($node.State -eq 'Down')
+                        if ($node.State -eq 'Down')
                         {
                             Write-Verbose -Message ($script:localizedData.RemoveOfflineNodeFromCluster -f $targetNodeName, $Name)
 
@@ -242,7 +240,7 @@ function Set-TargetResource
                 }
             }
 
-            foreach ($targetNodeName in $AllNodes)
+            foreach ($targetNodeName in $allNodes)
             {
                 Add-ClusterNode -Name $targetNodeName -Cluster $Name -NoStorage
 
@@ -360,9 +358,9 @@ function Test-TargetResource
 
             $existingNodes = Get-ClusterNode -Cluster $Name
 
-            $AllNodes = Get-All-Nodes($Nodes)
+            $allNodes = Get-AllNodes -Nodes $Nodes
 
-            foreach($targetNodeName in $AllNodes)
+            foreach ($targetNodeName in $allNodes)
             {
                 $found = $false
                 foreach ($node in $existingNodes)
@@ -380,7 +378,7 @@ function Test-TargetResource
                     }
                 }
 
-                if($false -eq $found)
+                if ($false -eq $found)
                 {
                     $returnValue = $false
                     break
@@ -527,7 +525,7 @@ function Close-UserToken
     .PARAMETER Nodes
         Array with node names
 #>
-function Get-All-Nodes
+function Get-AllNodes
 {
     [OutputType([String[]])]
     param
@@ -537,16 +535,16 @@ function Get-All-Nodes
         $Nodes
     )
 
-    $AllNodes = @()
-    $AllNodes += $env:COMPUTERNAME
+    $allNodes = @()
+    $allNodes += $env:COMPUTERNAME
 
-    if($null -ne $Nodes)
+    if ($null -ne $Nodes)
     {
-        $AllNodes += $Nodes
+        $allNodes += $Nodes
     }
 
     # Remove duplicates
-    $AllNodes = $AllNodes | Sort-Object -unique
+    $allNodes = $allNodes | Sort-Object -unique
 
-    return $AllNodes
+    return $allNodes
 }

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -4,7 +4,7 @@
 class MSFT_xCluster : OMI_BaseResource
 {
     [Key, Description("Name of the Cluster")] String Name;
-    [Write, Description("Additional Nodes of the Cluster")] String Nodes[];
+    [Write, Description("Additional Nodes of the Cluster. Default value is current node")] String Nodes[];
     [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
     [Write, Description("One or more networks to ignore when creating the cluster. Only networks using Static IP can be ignored, networks that are assigned an IP address through DHCP cannot be ignored, and are added for cluster communication. To remove networks assigned an IP address through DHCP use the resource xClusterNetwork to change the role of the network. This parameter is only used during the creation of the cluster and is not monitored after.")] String IgnoreNetwork[];

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -4,7 +4,7 @@
 class MSFT_xCluster : OMI_BaseResource
 {
     [Key, Description("Name of the Cluster")] String Name;
-    [Write, Description("Additional Nodes of the Cluster. Default value is current node")] String Nodes[];
+    [Write, Description("Additional Nodes of the Cluster. Default value is current node")] String Node[];
     [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
     [Write, Description("One or more networks to ignore when creating the cluster. Only networks using Static IP can be ignored, networks that are assigned an IP address through DHCP cannot be ignored, and are added for cluster communication. To remove networks assigned an IP address through DHCP use the resource xClusterNetwork to change the role of the network. This parameter is only used during the creation of the cluster and is not monitored after.")] String IgnoreNetwork[];

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -4,7 +4,7 @@
 class MSFT_xCluster : OMI_BaseResource
 {
     [Key, Description("Name of the Cluster")] String Name;
-    [Write, Description("Additional Nodes of the Cluster")] String[] Nodes;
+    [Write, Description("Additional Nodes of the Cluster")] String Nodes[];
     [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
     [Write, Description("One or more networks to ignore when creating the cluster. Only networks using Static IP can be ignored, networks that are assigned an IP address through DHCP cannot be ignored, and are added for cluster communication. To remove networks assigned an IP address through DHCP use the resource xClusterNetwork to change the role of the network. This parameter is only used during the creation of the cluster and is not monitored after.")] String IgnoreNetwork[];

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -4,6 +4,7 @@
 class MSFT_xCluster : OMI_BaseResource
 {
     [Key, Description("Name of the Cluster")] String Name;
+    [Write, Description("Additional Nodes of the Cluster")] String[] Nodes;
     [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
     [Write, Description("One or more networks to ignore when creating the cluster. Only networks using Static IP can be ignored, networks that are assigned an IP address through DHCP cannot be ignored, and are added for cluster communication. To remove networks assigned an IP address through DHCP use the resource xClusterNetwork to change the role of the network. This parameter is only used during the creation of the cluster and is not monitored after.")] String IgnoreNetwork[];

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ the target node ($env:COMPUTERNAME) to the cluster.
 * **`[String]` StaticIPAddress** _(Write)_: The static IP address of the failover
   cluster. If this is not specified then the IP address will be assigned from a
   DHCP.
+* **`[String[]]` Node** _(Write)_: Specifies a comma-separated list of cluster
+  node names to add to the local physical computer when creating a cluster. If
+  this parameter is not specified, then a one node cluster is created on the
+  local physical computer.
 * **`[String[]]` IgnoreNetwork** _(Write)_: One or more networks to ignore when
   creating the cluster. Only networks using Static IP can be ignored, networks
   that are assigned an IP address through DHCP cannot be ignored, and are added

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -312,17 +312,28 @@ try
                             }
                         }
 
-                        Context 'When Nodes is passed' {
+                        Context 'When Node is passed' {
                             It 'Should call New-Cluster cmdlet with Node as an array' {
                                 $withNodesParameter = $mockDefaultParameters + @{
-                                    Nodes = ('foo','bar')
+                                    Node = ('foo','bar')
                                 }
                                 { Set-TargetResource @withNodesParameter } | Should Not Throw
 
                                 Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It -ParameterFilter {
-                                    $Node.Contains($env:COMPUTERNAME) -eq $true `
-                                    -and $Node.Contains('foo') -eq $true `
+                                    $Node.Contains('foo') -eq $true `
                                     -and $Node.Contains('bar') -eq $true
+                                }
+                                Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
+                                Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It
+                            }
+                        }
+
+                        Context 'When Node is not passed' {
+                            It 'Should call New-Cluster cmdlet with Node as an array' {
+                                { Set-TargetResource @mockDefaultParameters } | Should Not Throw
+
+                                Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It -ParameterFilter {
+                                    $Node.Contains($env:COMPUTERNAME) -eq $true
                                 }
                                 Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
                                 Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -319,10 +319,7 @@ try
                                 }
                                 { Set-TargetResource @withNodesParameter } | Should Not Throw
 
-                                Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It -ParameterFilter {
-                                    $Nodes -eq 'foo' -and
-                                    $Nodes -eq 'bar'
-                                }
+                                Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
                                 Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
                                 Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It
                             }

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -319,7 +319,11 @@ try
                                 }
                                 { Set-TargetResource @withNodesParameter } | Should Not Throw
 
-                                Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
+                                Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It -ParameterFilter {
+                                    $Node.Contains($env:COMPUTERNAME) -eq $true `
+                                    -and $Node.Contains('foo') -eq $true `
+                                    -and $Node.Contains('bar') -eq $true
+                                }
                                 Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
                                 Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It
                             }

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -312,6 +312,22 @@ try
                             }
                         }
 
+                        Context 'When Nodes is passed' {
+                            It 'Should call New-Cluster cmdlet with Node as an array' {
+                                $withNodesParameter = $mockDefaultParameters + @{
+                                    Nodes = ('foo','bar')
+                                }
+                                { Set-TargetResource @withNodesParameter } | Should Not Throw
+
+                                Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It -ParameterFilter {
+                                    $Nodes -eq 'foo' -and
+                                    $Nodes -eq 'bar'
+                                }
+                                Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
+                                Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It
+                            }
+                        }
+
                         Context 'When IgnoreNetwork is passed as an array' {
                             It 'Should call New-Cluster cmdlet with IgnoreNetwork parameter' {
                                 $withIgnoreNetworkParameter = $mockDefaultParameters + @{ IgnoreNetwork = ('10.0.2.0/24', '192.168.4.0/24') }

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -422,7 +422,11 @@ try
                     It 'Should call both Remove-ClusterNode and Add-ClusterNode cmdlet' {
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
 
-                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
+                        $withDefaultNodeParameter = $mockDefaultParameters + @{
+                            Node = ($mockServerName)
+                        }
+
+                        { Set-TargetResource @withDefaultNodeParameter } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 1 -Scope It
@@ -568,8 +572,13 @@ try
                 $mockDynamicClusterNodeState = 'Up'
 
                 Context 'When the node already exist' {
+
+                    $withDefaultNodeParameter = $mockDefaultParameters + @{
+                        Node = ($mockServerName)
+                    }
+
                     It 'Should return $true' {
-                        $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
+                        $testTargetResourceResult = Test-TargetResource @withDefaultNodeParameter
                         $testTargetResourceResult | Should -Be $true
                     }
 

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -422,11 +422,7 @@ try
                     It 'Should call both Remove-ClusterNode and Add-ClusterNode cmdlet' {
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
 
-                        $withDefaultNodeParameter = $mockDefaultParameters + @{
-                            Node = ($mockServerName)
-                        }
-
-                        { Set-TargetResource @withDefaultNodeParameter } | Should -Not -Throw
+                        { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 
                         Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 1 -Scope It
@@ -573,12 +569,8 @@ try
 
                 Context 'When the node already exist' {
 
-                    $withDefaultNodeParameter = $mockDefaultParameters + @{
-                        Node = ($mockServerName)
-                    }
-
                     It 'Should return $true' {
-                        $testTargetResourceResult = Test-TargetResource @withDefaultNodeParameter
+                        $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
                         $testTargetResourceResult | Should -Be $true
                     }
 

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -418,7 +418,7 @@ try
                     }
 
                     BeforeEach {
-                        Mock -CommandName Get-ClusterNode -MockWith $mockGetClusterNode -ParameterFilter $mockGetClusterNode_ParameterFilter
+                        Mock -CommandName Get-ClusterNode -MockWith $mockGetClusterNode
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter
                     }
 

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -413,8 +413,13 @@ try
                 }
 
                 Context 'When the cluster exist and the node is down' {
+                    $mockGetClusterNode_ParameterFilter = {
+                        $Name -eq $mockDefaultParameters.Name
+                    }
+
                     BeforeEach {
-                        Mock -CommandName Get-ClusterNode -MockWith $mockGetClusterNode
+                        Mock -CommandName Get-ClusterNode -MockWith $mockGetClusterNode -ParameterFilter $mockGetClusterNode_ParameterFilter
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter
                     }
 
                     $mockDynamicClusterNodeState = 'Down'

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -417,15 +417,12 @@ try
                         $Name -eq $mockDefaultParameters.Name
                     }
 
-                    BeforeEach {
-                        Mock -CommandName Get-ClusterNode -MockWith $mockGetClusterNode
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter
-                    }
-
                     $mockDynamicClusterNodeState = 'Down'
 
                     It 'Should call both Remove-ClusterNode and Add-ClusterNode cmdlet' {
+                        Mock -CommandName Get-ClusterNode -MockWith $mockGetClusterNode -ParameterFilter $mockGetClusterNode_ParameterFilter
                         Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance -ParameterFilter $mockGetCimInstance_ParameterFilter
 
                         { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 


### PR DESCRIPTION
**Pull Request (PR) description**
Adds a "Nodes" string array parameter, specifying node names that will be added to the cluster along with the local computer at creation time (i.e passed to the New-Cluster command).

**This Pull Request (PR) fixes the following issues:**
#148, #157
The motivation behind this PR is that I was unable to join a secondary node to the cluster, tried both from the secondary node and from the primary node. The only way I had to achieve a cluster with more than one node was to specify all the nodes in the creation (using New-Cluster command and passing all the nodes into the -Node parameter).

**Task list:**
Will complete the task list if this PR makes sense to the owners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/177)
<!-- Reviewable:end -->
