### PR TITLE
xCluster - Update Cluster check to account for Paused Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Updated the xCluster *test* method to return true if a node is joined to the cluster but is in a **Paused** state.
+
 ## 1.12.0.0
 
 - Explicitly removed extra hidden files from release package

--- a/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -341,6 +341,11 @@ function Test-TargetResource
                     {
                         $returnValue = $true
                     }
+                    elseif ($node.State -eq 'Paused')
+                    {
+                        Write-Verbose -Message ($script:localizedData.ClusterNodePaused -f $targetNodeName, $Name)
+                        $returnValue = $true
+                    }
                     else
                     {
                         Write-Verbose -Message ($script:localizedData.ClusterNodeIsDown -f $targetNodeName, $Name)

--- a/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
+++ b/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
@@ -12,6 +12,7 @@ ConvertFrom-StringData @'
     ClusterNodeIsDown = Node {0} is in the cluster {1} but the status is not 'Up'. Node will be treated as NOT being a member of the cluster {1}.
     ClusterNodePresent = Cluster node {0} is a member of cluster {1}.
     ClusterNodeAbsent = Cluster node {0} is NOT a member of cluster {1}.
+    ClusterNodePaused = Cluster node {0} is a member of the cluster {1}.  It is currently in a PAUSED state.
     ClusterAbsentWithError = Cluster {0} is NOT present with error: {1}
     TargetNodeDomainMissing = Can't find the target node's domain name.
     ClusterNameNotFound = Can't find the cluster {0}.

--- a/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
+++ b/DSCResources/MSFT_xCluster/en-US/MSFT_xCluster.strings.psd1
@@ -12,7 +12,7 @@ ConvertFrom-StringData @'
     ClusterNodeIsDown = Node {0} is in the cluster {1} but the status is not 'Up'. Node will be treated as NOT being a member of the cluster {1}.
     ClusterNodePresent = Cluster node {0} is a member of cluster {1}.
     ClusterNodeAbsent = Cluster node {0} is NOT a member of cluster {1}.
-    ClusterNodePaused = Cluster node {0} is a member of the cluster {1}.  It is currently in a PAUSED state.
+    ClusterNodePaused = Cluster node {0} is a member of the cluster {1}. It is currently in a PAUSED state.
     ClusterAbsentWithError = Cluster {0} is NOT present with error: {1}
     TargetNodeDomainMissing = Can't find the target node's domain name.
     ClusterNameNotFound = Can't find the cluster {0}.

--- a/Tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/Tests/Unit/MSFT_xCluster.Tests.ps1
@@ -556,6 +556,15 @@ try
                             $testTargetResourceResult | Should -Be $true
                         }
 
+                    $mockDynamicClusterNodeState = 'Paused'
+
+                    Context 'When node exists and is in a Paused state' {
+                        It 'Should return $true' {
+                            $testTargetResourceResult = Test-TargetResource @mockDefaultParameters
+                            $testTargetResourceResult | Should -Be $true
+                        }
+                    }
+
                         Assert-VerifiableMock
                     }
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
Updated the cluster membership check to return true if the node is paused.  Added a localized string/verbose message to state the node is 'Paused' during the test method.

#### This Pull Request (PR) fixes the following issues

Fixes #201 

#### Task list

- [x] Update the Test method to account for joined nodes in a 'Paused' state.
- [x] Add a localized string/verbose message to state the node is already joined to the cluster and is in a 'Paused' state.
- [x] Add unit test for the new condition of a 'paused' node in cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfailovercluster/202)
<!-- Reviewable:end -->
